### PR TITLE
Keep the cmake modules FindLAPACK and FindBLAS in sync with the git repo of CMake

### DIFF
--- a/cmake/Modules/CheckFunctionExists.cmake
+++ b/cmake/Modules/CheckFunctionExists.cmake
@@ -1,0 +1,121 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+CheckFunctionExists
+-------------------
+
+Check if a C function can be linked
+
+.. command:: check_function_exists
+
+  .. code-block:: cmake
+
+    check_function_exists(<function> <variable>)
+
+  Checks that the ``<function>`` is provided by libraries on the system and store
+  the result in a ``<variable>``, which will be created as an internal
+  cache variable.
+
+The following variables may be set before calling this macro to modify the
+way the check is run:
+
+``CMAKE_REQUIRED_FLAGS``
+  string of compile command line flags.
+``CMAKE_REQUIRED_DEFINITIONS``
+  a :ref:`;-list <CMake Language Lists>` of macros to define (-DFOO=bar).
+``CMAKE_REQUIRED_INCLUDES``
+  a :ref:`;-list <CMake Language Lists>` of header search paths to pass to
+  the compiler.
+``CMAKE_REQUIRED_LINK_OPTIONS``
+  .. versionadded:: 3.14
+    a :ref:`;-list <CMake Language Lists>` of options to add to the link command.
+``CMAKE_REQUIRED_LIBRARIES``
+  a :ref:`;-list <CMake Language Lists>` of libraries to add to the link
+  command. See policy :policy:`CMP0075`.
+``CMAKE_REQUIRED_QUIET``
+  .. versionadded:: 3.1
+    execute quietly without messages.
+
+.. note::
+
+  Prefer using :Module:`CheckSymbolExists` instead of this module,
+  for the following reasons:
+
+  * ``check_function_exists()`` can't detect functions that are inlined
+    in headers or specified as a macro.
+
+  * ``check_function_exists()`` can't detect anything in the 32-bit
+    versions of the Win32 API, because of a mismatch in calling conventions.
+
+  * ``check_function_exists()`` only verifies linking, it does not verify
+    that the function is declared in system headers.
+#]=======================================================================]
+
+include_guard(GLOBAL)
+
+macro(CHECK_FUNCTION_EXISTS FUNCTION VARIABLE)
+  if(NOT DEFINED "${VARIABLE}" OR "x${${VARIABLE}}" STREQUAL "x${VARIABLE}")
+    set(MACRO_CHECK_FUNCTION_DEFINITIONS
+      "-DCHECK_FUNCTION_EXISTS=${FUNCTION} ${CMAKE_REQUIRED_FLAGS}")
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(CHECK_START "Looking for ${FUNCTION}")
+    endif()
+    if(CMAKE_REQUIRED_LINK_OPTIONS)
+      set(CHECK_FUNCTION_EXISTS_ADD_LINK_OPTIONS
+        LINK_OPTIONS ${CMAKE_REQUIRED_LINK_OPTIONS})
+    else()
+      set(CHECK_FUNCTION_EXISTS_ADD_LINK_OPTIONS)
+    endif()
+    if(CMAKE_REQUIRED_LIBRARIES)
+      set(CHECK_FUNCTION_EXISTS_ADD_LIBRARIES
+        LINK_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+    else()
+      set(CHECK_FUNCTION_EXISTS_ADD_LIBRARIES)
+    endif()
+    if(CMAKE_REQUIRED_INCLUDES)
+      set(CHECK_FUNCTION_EXISTS_ADD_INCLUDES
+        "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_REQUIRED_INCLUDES}")
+    else()
+      set(CHECK_FUNCTION_EXISTS_ADD_INCLUDES)
+    endif()
+
+    if(CMAKE_C_COMPILER_LOADED)
+      set(_cfe_source ${CMAKE_ROOT}/Modules/CheckFunctionExists.c)
+    elseif(CMAKE_CXX_COMPILER_LOADED)
+      set(_cfe_source ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CheckFunctionExists/CheckFunctionExists.cxx)
+      configure_file(${CMAKE_ROOT}/Modules/CheckFunctionExists.c "${_cfe_source}" COPYONLY)
+    else()
+      message(FATAL_ERROR "CHECK_FUNCTION_EXISTS needs either C or CXX language enabled")
+    endif()
+
+    try_compile(${VARIABLE}
+      ${CMAKE_BINARY_DIR}
+      ${_cfe_source}
+      COMPILE_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS}
+      ${CHECK_FUNCTION_EXISTS_ADD_LINK_OPTIONS}
+      ${CHECK_FUNCTION_EXISTS_ADD_LIBRARIES}
+      CMAKE_FLAGS -DCOMPILE_DEFINITIONS:STRING=${MACRO_CHECK_FUNCTION_DEFINITIONS}
+      "${CHECK_FUNCTION_EXISTS_ADD_INCLUDES}"
+      OUTPUT_VARIABLE OUTPUT)
+    unset(_cfe_source)
+
+    if(${VARIABLE})
+      set(${VARIABLE} 1 CACHE INTERNAL "Have function ${FUNCTION}")
+      if(NOT CMAKE_REQUIRED_QUIET)
+        message(CHECK_PASS "found")
+      endif()
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+        "Determining if the function ${FUNCTION} exists passed with the following output:\n"
+        "${OUTPUT}\n\n")
+    else()
+      if(NOT CMAKE_REQUIRED_QUIET)
+        message(CHECK_FAIL "not found")
+      endif()
+      set(${VARIABLE} "" CACHE INTERNAL "Have function ${FUNCTION}")
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+        "Determining if the function ${FUNCTION} exists failed with the following output:\n"
+        "${OUTPUT}\n\n")
+    endif()
+  endif()
+endmacro()

--- a/cmake/Modules/FindBLAS.cmake
+++ b/cmake/Modules/FindBLAS.cmake
@@ -1,58 +1,246 @@
-# - Find BLAS library
-# This module finds an installed fortran library that implements the BLAS
-# linear-algebra interface (see http://www.netlib.org/blas/).
-# The list of libraries searched for is taken
-# from the autoconf macro file, acx_blas.m4 (distributed at
-# http://ac-archive.sourceforge.net/ac-archive/acx_blas.html).
-#
-# This module sets the following variables:
-#  BLAS_FOUND - set to true if a library implementing the BLAS interface
-#    is found
-#  BLAS_LINKER_FLAGS - uncached list of required linker flags (excluding -l
-#    and -L).
-#  BLAS_LIBRARIES - uncached list of libraries (using full path name) to
-#    link against to use BLAS
-#  BLAS95_LIBRARIES - uncached list of libraries (using full path name)
-#    to link against to use BLAS95 interface
-#  BLAS95_FOUND - set to true if a library implementing the BLAS f95 interface
-#    is found
-#  BLA_STATIC  if set on this determines what kind of linkage we do (static)
-#  BLA_VENDOR  if set checks only the specified vendor, if not set checks
-#     all the possibilities
-#  BLA_F95     if set on tries to find the f95 interfaces for BLAS/LAPACK
-##########
-### List of vendors (BLA_VENDOR) valid in this module
-##  Goto,ATLAS PhiPACK,CXML,DXML,SunPerf,SCSL,SGIMATH,IBMESSL,Intel10_32 (intel mkl v10 32 bit),Intel10_64lp (intel mkl v10 64 bit,lp thread model, lp64 model),
-##  Intel10_64lp_seq (intel mkl v10 64 bit,sequential code, lp64 model),
-##  Intel11 (intel mkl v11)
-##  Intel( older versions of mkl 32 and 64 bit), ACML,ACML_MP,ACML_GPU,Apple, NAS, Generic
-# C/CXX should be enabled to use Intel mkl
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
 
-#=============================================================================
-# Copyright 2007-2009 Kitware, Inc.
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
-# (To distribute this file outside of CMake, substitute the full
-#  License text for the above reference.)
+#[=======================================================================[.rst:
+FindBLAS
+--------
 
-include(CheckFunctionExists)
-include(CheckFortranFunctionExists)
+Find Basic Linear Algebra Subprograms (BLAS) library
 
-set(_blas_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+This module finds an installed Fortran library that implements the
+`BLAS linear-algebra interface`_.
+
+At least one of the ``C``, ``CXX``, or ``Fortran`` languages must be enabled.
+
+.. _`BLAS linear-algebra interface`: http://www.netlib.org/blas/
+
+Input Variables
+^^^^^^^^^^^^^^^
+
+The following variables may be set to influence this module's behavior:
+
+``BLA_STATIC``
+  if ``ON`` use static linkage
+
+``BLA_VENDOR``
+  Set to one of the :ref:`BLAS/LAPACK Vendors` to search for BLAS only
+  from the specified vendor.  If not set, all vendors are considered.
+
+``BLA_F95``
+  if ``ON`` tries to find the BLAS95 interfaces
+
+``BLA_PREFER_PKGCONFIG``
+  .. versionadded:: 3.11
+
+  if set ``pkg-config`` will be used to search for a BLAS library first
+  and if one is found that is preferred
+
+``BLA_SIZEOF_INTEGER``
+  .. versionadded:: 3.22
+
+  Specify the BLAS/LAPACK library integer size:
+
+  ``4``
+    Search for a BLAS/LAPACK with 32-bit integer interfaces.
+  ``8``
+    Search for a BLAS/LAPACK with 64-bit integer interfaces.
+  ``ANY``
+    Search for any BLAS/LAPACK.
+    Most likely, a BLAS/LAPACK with 32-bit integer interfaces will be found.
+
+Imported targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` targets:
+
+``BLAS::BLAS``
+  .. versionadded:: 3.18
+
+  The libraries to use for BLAS, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``BLAS_FOUND``
+  library implementing the BLAS interface is found
+``BLAS_LINKER_FLAGS``
+  uncached list of required linker flags (excluding ``-l`` and ``-L``).
+``BLAS_LIBRARIES``
+  uncached list of libraries (using full path name) to link against
+  to use BLAS (may be empty if compiler implicitly links BLAS)
+``BLAS95_LIBRARIES``
+  uncached list of libraries (using full path name) to link against
+  to use BLAS95 interface
+``BLAS95_FOUND``
+  library implementing the BLAS95 interface is found
+
+.. _`BLAS/LAPACK Vendors`:
+
+BLAS/LAPACK Vendors
+^^^^^^^^^^^^^^^^^^^
+
+``Generic``
+  Generic reference implementation
+
+``ACML``, ``ACML_MP``, ``ACML_GPU``
+  AMD Core Math Library
+
+``Apple``, ``NAS``
+  Apple BLAS (Accelerate), and Apple NAS (vecLib)
+
+``Arm``, ``Arm_mp``, ``Arm_ilp64``, ``Arm_ilp64_mp``
+  .. versionadded:: 3.18
+
+  Arm Performance Libraries
+
+``ATLAS``
+  Automatically Tuned Linear Algebra Software
+
+``CXML``, ``DXML``
+  Compaq/Digital Extended Math Library
+
+``EML``, ``EML_mt``
+  .. versionadded:: 3.20
+
+  Elbrus Math Library
+
+``FLAME``
+  .. versionadded:: 3.11
+
+  BLIS Framework
+
+``FlexiBLAS``
+  .. versionadded:: 3.19
+
+``Fujitsu_SSL2``, ``Fujitsu_SSL2BLAMP``, ``Fujitsu_SSL2SVE``, ``Fujitsu_SSL2BLAMPSVE``
+  .. versionadded:: 3.20
+
+  Fujitsu SSL2 serial and parallel blas/lapack with SVE instructions
+
+``Goto``
+  GotoBLAS
+
+``IBMESSL``, ``IBMESSL_SMP``
+
+  IBM Engineering and Scientific Subroutine Library
+
+``Intel``
+  Intel MKL 32 bit and 64 bit obsolete versions
+
+``Intel10_32``
+  Intel MKL v10 32 bit, threaded code
+
+``Intel10_64lp``
+  Intel MKL v10+ 64 bit, threaded code, lp64 model
+
+``Intel10_64lp_seq``
+  Intel MKL v10+ 64 bit, sequential code, lp64 model
+
+``Intel10_64ilp``
+  .. versionadded:: 3.13
+
+  Intel MKL v10+ 64 bit, threaded code, ilp64 model
+
+``Intel10_64ilp_seq``
+  .. versionadded:: 3.13
+
+  Intel MKL v10+ 64 bit, sequential code, ilp64 model
+
+``Intel10_64_dyn``
+  .. versionadded:: 3.17
+
+  Intel MKL v10+ 64 bit, single dynamic library
+
+``NVHPC``
+  .. versionadded:: 3.21
+
+  NVIDIA HPC SDK
+
+``OpenBLAS``
+  .. versionadded:: 3.6
+
+``PhiPACK``
+  Portable High Performance ANSI C (PHiPAC)
+
+``SCSL``, ``SCSL_mp``
+  Scientific Computing Software Library
+
+``SGIMATH``
+  SGI Scientific Mathematical Library
+
+``SunPerf``
+  Sun Performance Library
+
+.. _`Intel MKL`:
+
+Intel MKL
+^^^^^^^^^
+
+To use the Intel MKL implementation of BLAS, a project must enable at least
+one of the ``C`` or ``CXX`` languages.  Set ``BLA_VENDOR`` to an Intel MKL
+variant either on the command-line as ``-DBLA_VENDOR=Intel10_64lp`` or in
+project code:
+
+.. code-block:: cmake
+
+  set(BLA_VENDOR Intel10_64lp)
+  find_package(BLAS)
+
+In order to build a project using Intel MKL, and end user must first
+establish an Intel MKL environment:
+
+Intel oneAPI
+  Source the full Intel environment script:
+
+  .. code-block:: shell
+
+    . /opt/intel/oneapi/setvars.sh
+
+  Or, source the MKL component environment script:
+
+  .. code-block:: shell
+
+    . /opt/intel/oneapi/mkl/latest/env/vars.sh
+
+Intel Classic
+  Source the full Intel environment script:
+
+  .. code-block:: shell
+
+    . /opt/intel/bin/compilervars.sh intel64
+
+  Or, source the MKL component environment script:
+
+  .. code-block:: shell
+
+    . /opt/intel/mkl/bin/mklvars.sh intel64
+
+The above environment scripts set the ``MKLROOT`` environment variable
+to the top of the MKL installation.  They also add the location of the
+runtime libraries to the dynamic library loader environment variable for
+your platform (e.g. ``LD_LIBRARY_PATH``).  This is necessary for programs
+linked against MKL to run.
+
+.. note::
+
+  As of Intel oneAPI 2021.2, loading only the MKL component does not
+  make all of its dependencies available.  In particular, the ``iomp5``
+  library must be available separately, or provided by also loading
+  the compiler component environment:
+
+  .. code-block:: shell
+
+    . /opt/intel/oneapi/compiler/latest/env/vars.sh
+
+#]=======================================================================]
+
+# The approach follows that of the ``autoconf`` macro file, ``acx_blas.m4``
+# (distributed at http://ac-archive.sourceforge.net/ac-archive/acx_blas.html).
 
 # Check the language being used
-get_property( _LANGUAGES_ GLOBAL PROPERTY ENABLED_LANGUAGES )
-if( _LANGUAGES_ MATCHES Fortran )
-  set( _CHECK_FORTRAN TRUE )
-elseif( (_LANGUAGES_ MATCHES C) OR (_LANGUAGES_ MATCHES CXX) )
-  set( _CHECK_FORTRAN FALSE )
-else()
+if(NOT (CMAKE_C_COMPILER_LOADED OR CMAKE_CXX_COMPILER_LOADED OR CMAKE_Fortran_COMPILER_LOADED))
   if(BLAS_FIND_REQUIRED)
     message(FATAL_ERROR "FindBLAS requires Fortran, C, or C++ to be enabled.")
   else()
@@ -61,581 +249,1095 @@ else()
   endif()
 endif()
 
-macro(Check_Fortran_Libraries LIBRARIES _prefix _name _flags _list _thread)
-# This macro checks for the existence of the combination of fortran libraries
-# given by _list.  If the combination is found, this macro checks (using the
-# Check_Fortran_Function_Exists macro) whether can link against that library
-# combination using the name of a routine given by _name using the linker
-# flags given by _flags.  If the combination of libraries is found and passes
-# the link test, LIBRARIES is set to the list of complete library paths that
-# have been found.  Otherwise, LIBRARIES is set to FALSE.
-
-# N.B. _prefix is the prefix applied to the names of all cached variables that
-# are generated internally and marked advanced by this macro.
-
-set(_libdir ${ARGN})
-
-set(_libraries_work TRUE)
-set(${LIBRARIES})
-set(_combined_name)
-if (NOT _libdir)
-  if (WIN32)
-    set(_libdir ENV LIB)
-  elseif (APPLE)
-    set(_libdir ENV DYLD_LIBRARY_PATH)
-  else ()
-    set(_libdir ENV LD_LIBRARY_PATH)
-  endif ()
-endif ()
-
-foreach(_library ${_list})
-  set(_combined_name ${_combined_name}_${_library})
-
-  if(_libraries_work)
-    if (BLA_STATIC)
-      if (WIN32)
-        set(CMAKE_FIND_LIBRARY_SUFFIXES .lib ${CMAKE_FIND_LIBRARY_SUFFIXES})
-      endif ()
-      if (APPLE)
-        set(CMAKE_FIND_LIBRARY_SUFFIXES .lib ${CMAKE_FIND_LIBRARY_SUFFIXES})
-      else ()
-        set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
-      endif ()
-    else ()
-      if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        # for ubuntu's libblas3gf and liblapack3gf packages
-        set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} .so.3gf)
-      endif ()
-      if (WIN32)
-        if (BLA_VENDOR MATCHES "^ACML")
-          #ACML library has a different naming convention
-          set(_library lib${_library}_dll)
-        endif()
-      endif()
-    endif ()
-    find_library(${_prefix}_${_library}_LIBRARY
-      NAMES ${_library}
-      PATHS ${_libdir}
+function(_add_blas_target)
+  if(BLAS_FOUND AND NOT TARGET BLAS::BLAS)
+    add_library(BLAS::BLAS INTERFACE IMPORTED)
+    if(BLAS_LIBRARIES)
+      set_target_properties(BLAS::BLAS PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${BLAS_LIBRARIES}"
       )
-    mark_as_advanced(${_prefix}_${_library}_LIBRARY)
-    if(${_prefix}_${_library}_LIBRARY)
-      set(${LIBRARIES} ${${LIBRARIES}} ${${_prefix}_${_library}_LIBRARY})
-      set(_libraries_work ${${_prefix}_${_library}_LIBRARY})
+    endif()
+    if(BLAS_LINKER_FLAGS)
+      set_target_properties(BLAS::BLAS PROPERTIES
+        INTERFACE_LINK_OPTIONS "${BLAS_LINKER_FLAGS}"
+      )
     endif()
   endif()
-endforeach()
-if(NOT ${LIBRARIES})
-  set(_libraries_work false)
+endfunction()
+
+if(CMAKE_Fortran_COMPILER_LOADED)
+  include(${CMAKE_CURRENT_LIST_DIR}/CheckFortranFunctionExists.cmake)
+else()
+  include(${CMAKE_CURRENT_LIST_DIR}/CheckFunctionExists.cmake)
 endif()
-if(_libraries_work)
-  # Test this combination of libraries.
-  set(CMAKE_REQUIRED_LIBRARIES ${_flags} ${${LIBRARIES}} ${_thread})
-  #message("DEBUG: CMAKE_REQUIRED_LIBRARIES = ${CMAKE_REQUIRED_LIBRARIES}")
-  if (_CHECK_FORTRAN)
-    check_fortran_function_exists("${_name}" ${_prefix}${_combined_name}_WORKS)
-  elseif(WIN32)
-    check_function_exists("${_name}" ${_prefix}${_combined_name}_WORKS)
-  else()
-    check_function_exists("${_name}_" ${_prefix}${_combined_name}_WORKS)
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+
+if(BLA_PREFER_PKGCONFIG)
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PKGC_BLAS QUIET blas)
+  if(PKGC_BLAS_FOUND)
+    set(BLAS_FOUND ${PKGC_BLAS_FOUND})
+    set(BLAS_LIBRARIES "${PKGC_BLAS_LINK_LIBRARIES}")
+    _add_blas_target()
+    return()
   endif()
-  set(CMAKE_REQUIRED_LIBRARIES)
-  mark_as_advanced(${_prefix}${_combined_name}_WORKS)
-  set(_libraries_work ${${_prefix}${_combined_name}_WORKS})
 endif()
-if(NOT _libraries_work)
-  set(${LIBRARIES} FALSE)
-endif()
-#message("DEBUG: ${LIBRARIES} = ${${LIBRARIES}}")
-endmacro()
+
+# TODO: move this stuff to a separate module
+
+function(CHECK_BLAS_LIBRARIES LIBRARIES _prefix _name _flags _list _deps _addlibdir _subdirs)
+  # This function checks for the existence of the combination of libraries
+  # given by _list.  If the combination is found, this checks whether can link
+  # against that library combination using the name of a routine given by _name
+  # using the linker flags given by _flags.  If the combination of libraries is
+  # found and passes the link test, ${LIBRARIES} is set to the list of complete
+  # library paths that have been found.  Otherwise, ${LIBRARIES} is set to FALSE.
+
+  set(_libraries_work TRUE)
+  set(_libraries)
+  set(_combined_name)
+
+  if(BLA_STATIC)
+    if(WIN32)
+      set(CMAKE_FIND_LIBRARY_SUFFIXES .lib ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    else()
+      set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    endif()
+  else()
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      # for ubuntu's libblas3gf and liblapack3gf packages
+      set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} .so.3gf)
+    endif()
+  endif()
+
+  set(_extaddlibdir "${_addlibdir}")
+  if(WIN32)
+    list(APPEND _extaddlibdir ENV LIB)
+  elseif(APPLE)
+    list(APPEND _extaddlibdir ENV DYLD_LIBRARY_PATH)
+  else()
+    list(APPEND _extaddlibdir ENV LD_LIBRARY_PATH)
+  endif()
+  list(APPEND _extaddlibdir "${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}")
+
+  foreach(_library ${_list})
+    if(_library MATCHES "^-")
+      # Respect linker flags as-is (required by MKL)
+      list(APPEND _libraries "${_library}")
+    else()
+      string(REGEX REPLACE "[^A-Za-z0-9]" "_" _lib_var "${_library}")
+      string(APPEND _combined_name "_${_lib_var}")
+      if(NOT "${_deps}" STREQUAL "")
+        string(APPEND _combined_name "_deps")
+      endif()
+      if(_libraries_work)
+        find_library(${_prefix}_${_lib_var}_LIBRARY
+          NAMES ${_library}
+          NAMES_PER_DIR
+          PATHS ${_extaddlibdir}
+          PATH_SUFFIXES ${_subdirs}
+        )
+        mark_as_advanced(${_prefix}_${_lib_var}_LIBRARY)
+        list(APPEND _libraries ${${_prefix}_${_lib_var}_LIBRARY})
+        set(_libraries_work ${${_prefix}_${_lib_var}_LIBRARY})
+      endif()
+    endif()
+  endforeach()
+
+  foreach(_flag ${_flags})
+    string(REGEX REPLACE "[^A-Za-z0-9]" "_" _flag_var "${_flag}")
+    string(APPEND _combined_name "_${_flag_var}")
+  endforeach()
+  if(_libraries_work)
+    # Test this combination of libraries.
+    set(CMAKE_REQUIRED_LIBRARIES ${_flags} ${_libraries} ${_deps})
+    set(CMAKE_REQUIRED_QUIET ${BLAS_FIND_QUIETLY})
+    if(CMAKE_Fortran_COMPILER_LOADED)
+      check_fortran_function_exists("${_name}" ${_prefix}${_combined_name}_WORKS)
+    else()
+      check_function_exists("${_name}_" ${_prefix}${_combined_name}_WORKS)
+    endif()
+    set(CMAKE_REQUIRED_LIBRARIES)
+    set(_libraries_work ${${_prefix}${_combined_name}_WORKS})
+  endif()
+
+  if(_libraries_work)
+    if("${_list}" STREQUAL "")
+      set(_libraries "${LIBRARIES}-PLACEHOLDER-FOR-EMPTY-LIBRARIES")
+    else()
+      list(APPEND _libraries ${_deps})
+    endif()
+  else()
+    set(_libraries FALSE)
+  endif()
+  set(${LIBRARIES} "${_libraries}" PARENT_SCOPE)
+endfunction()
 
 set(BLAS_LINKER_FLAGS)
 set(BLAS_LIBRARIES)
 set(BLAS95_LIBRARIES)
-if ($ENV{BLA_VENDOR} MATCHES ".+")
+set(_blas_fphsa_req_var BLAS_LIBRARIES)
+if(NOT $ENV{BLA_VENDOR} STREQUAL "")
   set(BLA_VENDOR $ENV{BLA_VENDOR})
-else ()
+else()
   if(NOT BLA_VENDOR)
     set(BLA_VENDOR "All")
   endif()
-endif ()
+endif()
 
-if (BLA_VENDOR STREQUAL "Goto" OR BLA_VENDOR STREQUAL "All")
- if(NOT BLAS_LIBRARIES)
-  # gotoblas (http://www.tacc.utexas.edu/tacc-projects/gotoblas2)
-  check_fortran_libraries(
-  BLAS_LIBRARIES
-  BLAS
-  sgemm
-  ""
-  "goto2"
-  ""
-  )
- endif()
-endif ()
+if(NOT BLA_SIZEOF_INTEGER)
+  # in the reality we do not know which API of BLAS/LAPACK is masked in library
+  set(_blas_sizeof_integer "ANY")
+elseif((BLA_SIZEOF_INTEGER STREQUAL "ANY") OR
+       (BLA_SIZEOF_INTEGER STREQUAL "4") OR
+       (BLA_SIZEOF_INTEGER STREQUAL "8"))
+  set(_blas_sizeof_integer ${BLA_SIZEOF_INTEGER})
+else()
+  message(FATAL_ERROR "BLA_SIZEOF_INTEGER can have only <no value>, ANY, 4, or 8 values")
+endif()
 
-if (BLA_VENDOR STREQUAL "ATLAS" OR BLA_VENDOR STREQUAL "All")
- if(NOT BLAS_LIBRARIES)
-  # BLAS in ATLAS library? (http://math-atlas.sourceforge.net/)
-  check_fortran_libraries(
-  BLAS_LIBRARIES
-  BLAS
-  dgemm
-  "gfortran"
-  "f77blas;satlas;tatlas;atlas"
-  ""
-  )
- endif()
-endif ()
-
-# BLAS in PhiPACK libraries? (requires generic BLAS lib, too)
-if (BLA_VENDOR STREQUAL "PhiPACK" OR BLA_VENDOR STREQUAL "All")
- if(NOT BLAS_LIBRARIES)
-  check_fortran_libraries(
-  BLAS_LIBRARIES
-  BLAS
-  sgemm
-  ""
-  "sgemm;dgemm;blas"
-  ""
-  )
- endif()
-endif ()
-
-# BLAS in Alpha CXML library?
-if (BLA_VENDOR STREQUAL "CXML" OR BLA_VENDOR STREQUAL "All")
- if(NOT BLAS_LIBRARIES)
-  check_fortran_libraries(
-  BLAS_LIBRARIES
-  BLAS
-  sgemm
-  ""
-  "cxml"
-  ""
-  )
- endif()
-endif ()
-
-# BLAS in Alpha DXML library? (now called CXML, see above)
-if (BLA_VENDOR STREQUAL "DXML" OR BLA_VENDOR STREQUAL "All")
- if(NOT BLAS_LIBRARIES)
-  check_fortran_libraries(
-  BLAS_LIBRARIES
-  BLAS
-  sgemm
-  ""
-  "dxml"
-  ""
-  )
- endif()
-endif ()
-
-# BLAS in Sun Performance library?
-if (BLA_VENDOR STREQUAL "SunPerf" OR BLA_VENDOR STREQUAL "All")
- if(NOT BLAS_LIBRARIES)
-  check_fortran_libraries(
-  BLAS_LIBRARIES
-  BLAS
-  sgemm
-  "-xlic_lib=sunperf"
-  "sunperf;sunmath"
-  ""
-  )
-  if(BLAS_LIBRARIES)
-    set(BLAS_LINKER_FLAGS "-xlic_lib=sunperf")
-  endif()
- endif()
-endif ()
-
-# BLAS in SCSL library?  (SGI/Cray Scientific Library)
-if (BLA_VENDOR STREQUAL "SCSL" OR BLA_VENDOR STREQUAL "All")
- if(NOT BLAS_LIBRARIES)
-  check_fortran_libraries(
-  BLAS_LIBRARIES
-  BLAS
-  sgemm
-  ""
-  "scsl"
-  ""
-  )
- endif()
-endif ()
-
-# BLAS in SGIMATH library?
-if (BLA_VENDOR STREQUAL "SGIMATH" OR BLA_VENDOR STREQUAL "All")
- if(NOT BLAS_LIBRARIES)
-  check_fortran_libraries(
-  BLAS_LIBRARIES
-  BLAS
-  sgemm
-  ""
-  "complib.sgimath"
-  ""
-  )
- endif()
-endif ()
-
-# BLAS in IBM ESSL library? (requires generic BLAS lib, too)
-if (BLA_VENDOR STREQUAL "IBMESSL" OR BLA_VENDOR STREQUAL "All")
- if(NOT BLAS_LIBRARIES)
-  check_fortran_libraries(
-  BLAS_LIBRARIES
-  BLAS
-  sgemm
-  ""
-  "essl;blas"
-  ""
-  )
- endif()
-endif ()
-
-#BLAS in acml library?
-if (BLA_VENDOR MATCHES "ACML.*" OR BLA_VENDOR STREQUAL "All")
- if( ((BLA_VENDOR STREQUAL "ACML") AND (NOT BLAS_ACML_LIB_DIRS)) OR
-     ((BLA_VENDOR STREQUAL "ACML_MP") AND (NOT BLAS_ACML_MP_LIB_DIRS)) OR
-     ((BLA_VENDOR STREQUAL "ACML_GPU") AND (NOT BLAS_ACML_GPU_LIB_DIRS))
-   )
-   # try to find acml in "standard" paths
-   if( WIN32 )	   
-    file( GLOB _ACML_ROOT "C:/AMD/acml*/ACML-EULA.txt" )
-   else()
-    file( GLOB _ACML_ROOT "/opt/acml*/ACML-EULA.txt" )
-   endif()
-   if( WIN32 )
-    file( GLOB _ACML_GPU_ROOT "C:/AMD/acml*/GPGPUexamples" )
-   else()
-    file( GLOB _ACML_GPU_ROOT "/opt/acml*/GPGPUexamples" )
-   endif()
-   if( _ACML_GPU_ROOT )
-    list(GET _ACML_GPU_ROOT 0 _ACML_GPU_ROOT)
-   endif()
-   if( _ACML_ROOT )
-    list(GET _ACML_ROOT 0 _ACML_ROOT)
-    get_filename_component( _ACML_ROOT ${_ACML_ROOT} PATH )
-    if( SIZEOF_INTEGER EQUAL 8 )
-     set( _ACML_PATH_SUFFIX "_int64" )
-    else()
-    set( _ACML_PATH_SUFFIX "" )
-   endif()
-   if( CMAKE_Fortran_COMPILER_ID STREQUAL "Intel" )
-    set( _ACML_COMPILER32 "ifort32" )
-    set( _ACML_COMPILER64 "ifort64" )
-   elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "SunPro" )
-    set( _ACML_COMPILER32 "sun32" )
-    set( _ACML_COMPILER64 "sun64" )
-   elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "PGI" )
-    set( _ACML_COMPILER32 "pgi32" )
-    if( WIN32 )
-     set( _ACML_COMPILER64 "win64" )
-    else()
-     set( _ACML_COMPILER64 "pgi64" )
-    endif()
-   elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "Open64" )
-    # 32 bit builds not supported on Open64 but for code simplicity
-    # We'll just use the same directory twice
-    set( _ACML_COMPILER32 "open64_64" )
-    set( _ACML_COMPILER64 "open64_64" )
-   elseif( CMAKE_Fortran_COMPILER_ID STREQUAL "NAG" )
-    set( _ACML_COMPILER32 "nag32" )
-    set( _ACML_COMPILER64 "nag64" )
-   else()
-    set( _ACML_COMPILER32 "gfortran32" )
-    set( _ACML_COMPILER64 "gfortran64" )
-   endif()
-
-   if( BLA_VENDOR STREQUAL "ACML_MP" )
-    set(_ACML_MP_LIB_DIRS
-     "${_ACML_ROOT}/${_ACML_COMPILER32}_mp${_ACML_PATH_SUFFIX}/lib"
-     "${_ACML_ROOT}/${_ACML_COMPILER64}_mp${_ACML_PATH_SUFFIX}/lib" )
-   else()
-    set(_ACML_LIB_DIRS
-     "${_ACML_ROOT}/${_ACML_COMPILER32}${_ACML_PATH_SUFFIX}/lib"
-     "${_ACML_ROOT}/${_ACML_COMPILER64}${_ACML_PATH_SUFFIX}/lib" )
-   endif()
-  endif()
- elseif(BLAS_${BLA_VENDOR}_LIB_DIRS)
-   set(_${BLA_VENDOR}_LIB_DIRS ${BLAS_${BLA_VENDOR}_LIB_DIRS})
- endif()
-
- if( BLA_VENDOR STREQUAL "ACML_MP" )
-  foreach( BLAS_ACML_MP_LIB_DIRS ${_ACML_MP_LIB_DIRS})
-   check_fortran_libraries (
-     BLAS_LIBRARIES
-     BLAS
-     sgemm
-     "" "acml_mp;acml_mv" "" ${BLAS_ACML_MP_LIB_DIRS}
-   )
-   if( BLAS_LIBRARIES )
-    break()
-   endif()
-  endforeach()
- elseif( BLA_VENDOR STREQUAL "ACML_GPU" )
-  foreach( BLAS_ACML_GPU_LIB_DIRS ${_ACML_GPU_LIB_DIRS})
-   check_fortran_libraries (
-     BLAS_LIBRARIES
-     BLAS
-     sgemm
-     "" "acml;acml_mv;CALBLAS" "" ${BLAS_ACML_GPU_LIB_DIRS}
-   )
-   if( BLAS_LIBRARIES )
-    break()
-   endif()
-  endforeach()
- else()
-  foreach( BLAS_ACML_LIB_DIRS ${_ACML_LIB_DIRS} )
-   check_fortran_libraries (
-     BLAS_LIBRARIES
-     BLAS
-     sgemm
-     "" "acml;acml_mv" "" ${BLAS_ACML_LIB_DIRS}
-   )
-   if( BLAS_LIBRARIES )
-    break()
-   endif()
-  endforeach()
- endif()
-
- # Either acml or acml_mp should be in LD_LIBRARY_PATH but not both
- if(NOT BLAS_LIBRARIES)
-  check_fortran_libraries(
-  BLAS_LIBRARIES
-  BLAS
-  sgemm
-  ""
-  "acml;acml_mv"
-  ""
-  )
- endif()
- if(NOT BLAS_LIBRARIES)
-  check_fortran_libraries(
-  BLAS_LIBRARIES
-  BLAS
-  sgemm
-  ""
-  "acml_mp;acml_mv"
-  ""
-  )
- endif()
- if(NOT BLAS_LIBRARIES)
-  check_fortran_libraries(
-  BLAS_LIBRARIES
-  BLAS
-  sgemm
-  ""
-  "acml;acml_mv;CALBLAS"
-  ""
-  )
- endif()
-endif () # ACML
-
-# Apple BLAS library?
-if (BLA_VENDOR STREQUAL "Apple" OR BLA_VENDOR STREQUAL "All")
-if(NOT BLAS_LIBRARIES)
-  check_fortran_libraries(
-  BLAS_LIBRARIES
-  BLAS
-  dgemm
-  ""
-  "Accelerate"
-  ""
-  )
- endif()
-endif ()
-
-if (BLA_VENDOR STREQUAL "NAS" OR BLA_VENDOR STREQUAL "All")
- if ( NOT BLAS_LIBRARIES )
-    check_fortran_libraries(
-    BLAS_LIBRARIES
-    BLAS
-    dgemm
-    ""
-    "vecLib"
-    ""
-    )
- endif ()
-endif ()
-
-# Generic BLAS library?
-if (BLA_VENDOR STREQUAL "Generic" OR BLA_VENDOR STREQUAL "All")
+# Implicitly linked BLAS libraries?
+if(BLA_VENDOR STREQUAL "All")
   if(NOT BLAS_LIBRARIES)
-    if (BLA_STATIC)
-      set(_flags "gfortran") #needed by itpp-external
-    else()
-      set(_flags " ")
-    endif()
-    check_fortran_libraries(
+    check_blas_libraries(
       BLAS_LIBRARIES
       BLAS
       sgemm
-      ${_flags}
-      "blas"
       ""
-    )
- endif()
-endif ()
-
-#BLAS in intel mkl 10, 11 library? (em64t 64bit)
-if (BLA_VENDOR MATCHES "Intel*" OR BLA_VENDOR STREQUAL "All")
- if (NOT WIN32)
-  set(LM "-lm")
- endif ()
- if (_LANGUAGES_ MATCHES C OR _LANGUAGES_ MATCHES CXX)
-  if(BLAS_FIND_QUIETLY OR NOT BLAS_FIND_REQUIRED)
-    find_package(Threads)
-  else()
-    find_package(Threads REQUIRED)
+      ""
+      ""
+      ""
+      ""
+      )
   endif()
+  if(BLAS_WORKS)
+    # Give a more helpful "found" message
+    set(BLAS_WORKS "implicitly linked")
+    set(_blas_fphsa_req_var BLAS_WORKS)
+  endif()
+endif()
 
-  set(BLAS_SEARCH_LIBS "")
+# BLAS in the Intel MKL 10+ library?
+if(BLA_VENDOR MATCHES "Intel" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    if(CMAKE_C_COMPILER_LOADED OR CMAKE_CXX_COMPILER_LOADED)
+      # System-specific settings
+      if(WIN32)
+        if(BLA_STATIC)
+          set(BLAS_mkl_DLL_SUFFIX "")
+        else()
+          set(BLAS_mkl_DLL_SUFFIX "_dll")
+        endif()
+      else()
+        if(BLA_STATIC)
+          set(BLAS_mkl_START_GROUP "-Wl,--start-group")
+          set(BLAS_mkl_END_GROUP "-Wl,--end-group")
+        else()
+          set(BLAS_mkl_START_GROUP "")
+          set(BLAS_mkl_END_GROUP "")
+        endif()
+        # Switch to GNU Fortran support layer if needed (but not on Apple, where MKL does not provide it)
+        if(CMAKE_Fortran_COMPILER_LOADED AND (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "LCC") AND NOT APPLE)
+            set(BLAS_mkl_INTFACE "gf")
+            set(BLAS_mkl_THREADING "gnu")
+            set(BLAS_mkl_OMP "gomp")
+        else()
+            set(BLAS_mkl_INTFACE "intel")
+            set(BLAS_mkl_THREADING "intel")
+            set(BLAS_mkl_OMP "iomp5")
+        endif()
+        set(BLAS_mkl_LM "-lm")
+        set(BLAS_mkl_LDL "-ldl")
+      endif()
 
-  if(BLA_F95)
-    set(BLAS_mkl_SEARCH_SYMBOL SGEMM)
-    set(_LIBRARIES BLAS95_LIBRARIES)
-    if (WIN32)
-      list(APPEND BLAS_SEARCH_LIBS
-        "mkl_blas95 mkl_intel_c mkl_intel_thread mkl_core libguide40")
-    else ()
-      if (BLA_VENDOR STREQUAL "Intel10_32" OR BLA_VENDOR STREQUAL "All")
-        list(APPEND BLAS_SEARCH_LIBS
-          "mkl_blas95 mkl_intel mkl_intel_thread mkl_core guide")
-      endif ()
-      if (BLA_VENDOR STREQUAL "Intel10_64lp" OR BLA_VENDOR STREQUAL "All")
-        # old version
-        list(APPEND BLAS_SEARCH_LIBS
-          "mkl_blas95 mkl_intel_lp64 mkl_intel_thread mkl_core guide")
+      if(BLAS_FIND_QUIETLY OR NOT BLAS_FIND_REQUIRED)
+        find_package(Threads)
+      else()
+        find_package(Threads REQUIRED)
+      endif()
 
-        # mkl >= 10.3
-        if (CMAKE_C_COMPILER MATCHES ".+gcc.*")
-          list(APPEND BLAS_SEARCH_LIBS
-            "mkl_blas95_lp64 mkl_intel_lp64 mkl_gnu_thread mkl_core gomp")
-        else ()
-          list(APPEND BLAS_SEARCH_LIBS
-            "mkl_blas95_lp64 mkl_intel_lp64 mkl_intel_thread mkl_core iomp5")
-        endif ()
-      endif ()
-    endif ()
-    if (BLA_VENDOR STREQUAL "Intel10_64lp_seq" OR BLA_VENDOR STREQUAL "All")
-      list(APPEND BLAS_SEARCH_LIBS
-        "mkl_blas95_lp64 mkl_intel_lp64 mkl_sequential mkl_core")
-    endif ()
-  else ()
-    set(BLAS_mkl_SEARCH_SYMBOL sgemm)
-    set(_LIBRARIES BLAS_LIBRARIES)
-    if (WIN32)
-      # mkl >= 11
-      if (BLA_VENDOR MATCHES "Intel11*")
+      if(_blas_sizeof_integer EQUAL 8)
+        set(BLAS_mkl_ILP_MODE "ilp64")
+      elseif(_blas_sizeof_integer EQUAL 4)
+        set(BLAS_mkl_ILP_MODE "lp64")
+      else()
+        if(BLA_VENDOR MATCHES "_64ilp")
+          set(BLAS_mkl_ILP_MODE "ilp64")
+        else()
+          set(BLAS_mkl_ILP_MODE "lp64")
+        endif()
+      endif()
+
+      set(BLAS_SEARCH_LIBS "")
+
+      if(BLA_F95)
+        set(BLAS_mkl_SEARCH_SYMBOL "sgemm_f95")
+        set(_BLAS_LIBRARIES BLAS95_LIBRARIES)
+        if(WIN32)
+          # Find the main file (32-bit or 64-bit)
+          set(BLAS_SEARCH_LIBS_WIN_MAIN "")
+          if(BLA_VENDOR STREQUAL "Intel10_32" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_MAIN
+              "mkl_blas95${BLAS_mkl_DLL_SUFFIX} mkl_intel_c${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_MAIN
+              "mkl_blas95_${BLAS_mkl_ILP_MODE}${BLAS_mkl_DLL_SUFFIX} mkl_intel_${BLAS_mkl_ILP_MODE}${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+
+          # Add threading/sequential libs
+          set(BLAS_SEARCH_LIBS_WIN_THREAD "")
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp$" OR BLA_VENDOR STREQUAL "All")
+            # old version
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "libguide40 mkl_intel_thread${BLAS_mkl_DLL_SUFFIX}")
+            # mkl >= 10.3
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "libiomp5md mkl_intel_thread${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp_seq$" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "mkl_sequential${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+
+          # Cartesian product of the above
+          foreach(MAIN ${BLAS_SEARCH_LIBS_WIN_MAIN})
+            foreach(THREAD ${BLAS_SEARCH_LIBS_WIN_THREAD})
+              list(APPEND BLAS_SEARCH_LIBS
+                "${MAIN} ${THREAD} mkl_core${BLAS_mkl_DLL_SUFFIX}")
+            endforeach()
+          endforeach()
+        else()
+          if(BLA_VENDOR STREQUAL "Intel10_32" OR BLA_VENDOR STREQUAL "All")
+            # old version
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl_blas95 mkl_${BLAS_mkl_INTFACE} mkl_${BLAS_mkl_THREADING}_thread mkl_core guide")
+
+            # mkl >= 10.3
+            list(APPEND BLAS_SEARCH_LIBS
+              "${BLAS_mkl_START_GROUP} mkl_blas95 mkl_${BLAS_mkl_INTFACE} mkl_${BLAS_mkl_THREADING}_thread mkl_core ${BLAS_mkl_END_GROUP} ${BLAS_mkl_OMP}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp$" OR BLA_VENDOR STREQUAL "All")
+            # old version
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl_blas95 mkl_${BLAS_mkl_INTFACE}_${BLAS_mkl_ILP_MODE} mkl_${BLAS_mkl_THREADING}_thread mkl_core guide")
+
+            # mkl >= 10.3
+            list(APPEND BLAS_SEARCH_LIBS
+              "${BLAS_mkl_START_GROUP} mkl_blas95_${BLAS_mkl_ILP_MODE} mkl_${BLAS_mkl_INTFACE}_${BLAS_mkl_ILP_MODE} mkl_${BLAS_mkl_THREADING}_thread mkl_core ${BLAS_mkl_END_GROUP} ${BLAS_mkl_OMP}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp_seq$" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS
+              "${BLAS_mkl_START_GROUP} mkl_blas95_${BLAS_mkl_ILP_MODE} mkl_${BLAS_mkl_INTFACE}_${BLAS_mkl_ILP_MODE} mkl_sequential mkl_core ${BLAS_mkl_END_GROUP}")
+          endif()
+        endif()
+      else()
+        set(BLAS_mkl_SEARCH_SYMBOL sgemm)
+        set(_BLAS_LIBRARIES BLAS_LIBRARIES)
+        if(WIN32)
+          # Find the main file (32-bit or 64-bit)
+          set(BLAS_SEARCH_LIBS_WIN_MAIN "")
+          if(BLA_VENDOR STREQUAL "Intel10_32" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_MAIN
+              "mkl_intel_c${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_MAIN
+              "mkl_intel_${BLAS_mkl_ILP_MODE}${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+
+          # Add threading/sequential libs
+          set(BLAS_SEARCH_LIBS_WIN_THREAD "")
+          if(BLA_VENDOR STREQUAL "Intel10_32" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "libiomp5md mkl_intel_thread${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp$" OR BLA_VENDOR STREQUAL "All")
+            # old version
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "libguide40 mkl_intel_thread${BLAS_mkl_DLL_SUFFIX}")
+            # mkl >= 10.3
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "libiomp5md mkl_intel_thread${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp_seq$" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS_WIN_THREAD
+              "mkl_sequential${BLAS_mkl_DLL_SUFFIX}")
+          endif()
+
+          # Cartesian product of the above
+          foreach(MAIN ${BLAS_SEARCH_LIBS_WIN_MAIN})
+            foreach(THREAD ${BLAS_SEARCH_LIBS_WIN_THREAD})
+              list(APPEND BLAS_SEARCH_LIBS
+                "${MAIN} ${THREAD} mkl_core${BLAS_mkl_DLL_SUFFIX}")
+            endforeach()
+          endforeach()
+        else()
+          if(BLA_VENDOR STREQUAL "Intel10_32" OR BLA_VENDOR STREQUAL "All")
+            # old version
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl_${BLAS_mkl_INTFACE} mkl_${BLAS_mkl_THREADING}_thread mkl_core guide")
+
+            # mkl >= 10.3
+            list(APPEND BLAS_SEARCH_LIBS
+              "${BLAS_mkl_START_GROUP} mkl_${BLAS_mkl_INTFACE} mkl_${BLAS_mkl_THREADING}_thread mkl_core ${BLAS_mkl_END_GROUP} ${BLAS_mkl_OMP}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp$" OR BLA_VENDOR STREQUAL "All")
+            # old version
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl_${BLAS_mkl_INTFACE}_${BLAS_mkl_ILP_MODE} mkl_${BLAS_mkl_THREADING}_thread mkl_core guide")
+
+            # mkl >= 10.3
+            list(APPEND BLAS_SEARCH_LIBS
+              "${BLAS_mkl_START_GROUP} mkl_${BLAS_mkl_INTFACE}_${BLAS_mkl_ILP_MODE} mkl_${BLAS_mkl_THREADING}_thread mkl_core ${BLAS_mkl_END_GROUP} ${BLAS_mkl_OMP}")
+          endif()
+          if(BLA_VENDOR MATCHES "^Intel10_64i?lp_seq$" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS
+              "${BLAS_mkl_START_GROUP} mkl_${BLAS_mkl_INTFACE}_${BLAS_mkl_ILP_MODE} mkl_sequential mkl_core ${BLAS_mkl_END_GROUP}")
+          endif()
+
+          #older versions of intel mkl libs
+          if(BLA_VENDOR STREQUAL "Intel" OR BLA_VENDOR STREQUAL "All")
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl")
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl_ia32")
+            list(APPEND BLAS_SEARCH_LIBS
+              "mkl_em64t")
+          endif()
+        endif()
+      endif()
+
+      if(BLA_VENDOR MATCHES "^Intel10_64_dyn$" OR BLA_VENDOR STREQUAL "All")
+        # mkl >= 10.3 with single dynamic library
         list(APPEND BLAS_SEARCH_LIBS
           "mkl_rt")
+      endif()
+
+      # MKL uses a multitude of partially platform-specific subdirectories:
+      if(BLA_VENDOR STREQUAL "Intel10_32")
+        set(BLAS_mkl_ARCH_NAME "ia32")
       else()
-        list(APPEND BLAS_SEARCH_LIBS
-          "mkl_c_dll mkl_intel_thread_dll mkl_core_dll libguide40")
+        set(BLAS_mkl_ARCH_NAME "intel64")
       endif()
-    else ()
-      if (BLA_VENDOR STREQUAL "Intel10_32" OR BLA_VENDOR STREQUAL "All")
-        list(APPEND BLAS_SEARCH_LIBS
-          "mkl_intel mkl_intel_thread mkl_core guide")
-      endif ()
-      if (BLA_VENDOR STREQUAL "Intel10_64lp" OR BLA_VENDOR STREQUAL "All")
-
-        # old version
-        list(APPEND BLAS_SEARCH_LIBS
-          "mkl_intel_lp64 mkl_intel_thread mkl_core guide")
-
-        # mkl >= 10.3
-        if (CMAKE_C_COMPILER MATCHES ".+gcc.*")
-          list(APPEND BLAS_SEARCH_LIBS
-            "mkl_intel_lp64 mkl_gnu_thread mkl_core gomp")
-        else ()
-          list(APPEND BLAS_SEARCH_LIBS
-            "mkl_intel_lp64 mkl_intel_thread mkl_core iomp5")
-        endif ()
-      endif ()
-
-      #mkl 11
-      if (BLA_VENDOR MATCHES "Intel11*")
-        list(APPEND BLAS_SEARCH_LIBS
-          "mkl_rt")
-      endif()
-
-      #older vesions of intel mkl libs
-      if (BLA_VENDOR STREQUAL "Intel" OR BLA_VENDOR STREQUAL "All")
-        list(APPEND BLAS_SEARCH_LIBS
-          "mkl")
-        list(APPEND BLAS_SEARCH_LIBS
-          "mkl_ia32")
-        list(APPEND BLAS_SEARCH_LIBS
-          "mkl_em64t")
-      endif ()
-    endif ()
-    if (BLA_VENDOR STREQUAL "Intel10_64lp_seq" OR BLA_VENDOR STREQUAL "All")
-      list(APPEND BLAS_SEARCH_LIBS
-        "mkl_intel_lp64 mkl_sequential mkl_core")
-    endif ()
-  endif ()
-
-  foreach (IT ${BLAS_SEARCH_LIBS})
-    string(REPLACE " " ";" SEARCH_LIBS ${IT})
-    if (${_LIBRARIES})
-    else ()
-      check_fortran_libraries(
-        ${_LIBRARIES}
-        BLAS
-        ${BLAS_mkl_SEARCH_SYMBOL}
-        ""
-        "${SEARCH_LIBS}"
-        "${CMAKE_THREAD_LIBS_INIT};${LM}"
-        )
-    endif ()
-  endforeach ()
-
- endif ()
-endif ()
-
-
-if(BLA_F95)
- if(BLAS95_LIBRARIES)
-    set(BLAS95_FOUND TRUE)
-    set(BLAS_FOUND TRUE)
-  else()
-    set(BLAS95_FOUND FALSE)
-    set(BLAS_FOUND FALSE)
-  endif()
-
-  if(NOT BLAS_FIND_QUIETLY)
-    if(BLAS95_FOUND)
-      message(STATUS "A library with BLAS95 API found.")
-    else()
-      if(BLAS_FIND_REQUIRED)
-        message(FATAL_ERROR
-        "A required library with BLAS95 API not found. Please specify library location.")
+      if(WIN32)
+        set(BLAS_mkl_OS_NAME "win")
+      elseif(APPLE)
+        set(BLAS_mkl_OS_NAME "mac")
       else()
-        message(STATUS
-        "A library with BLAS95 API not found. Please specify library location.")
+        set(BLAS_mkl_OS_NAME "lin")
       endif()
-    endif()
-  endif()
-  set(BLAS_LIBRARIES "${BLAS95_LIBRARIES}")
-else()
-  if(BLAS_LIBRARIES)
-    set(BLAS_FOUND TRUE)
-  else()
-    set(BLAS_FOUND FALSE)
-  endif()
+      if(DEFINED ENV{MKLROOT})
+        file(TO_CMAKE_PATH "$ENV{MKLROOT}" BLAS_mkl_MKLROOT)
+        # If MKLROOT points to the subdirectory 'mkl', use the parent directory instead
+        # so we can better detect other relevant libraries in 'compiler' or 'tbb':
+        get_filename_component(BLAS_mkl_MKLROOT_LAST_DIR "${BLAS_mkl_MKLROOT}" NAME)
+        if(BLAS_mkl_MKLROOT_LAST_DIR STREQUAL "mkl")
+            get_filename_component(BLAS_mkl_MKLROOT "${BLAS_mkl_MKLROOT}" DIRECTORY)
+        endif()
+      endif()
+      set(BLAS_mkl_LIB_PATH_SUFFIXES
+          "compiler/lib" "compiler/lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}"
+          "compiler/lib/${BLAS_mkl_ARCH_NAME}"
+          "mkl/lib" "mkl/lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}"
+          "mkl/lib/${BLAS_mkl_ARCH_NAME}"
+          "lib" "lib/${BLAS_mkl_ARCH_NAME}_${BLAS_mkl_OS_NAME}"
+          "lib/${BLAS_mkl_ARCH_NAME}"
+          )
 
-  if(NOT BLAS_FIND_QUIETLY)
-    if(BLAS_FOUND)
-      message(STATUS "A library with BLAS API found.")
-    else()
-      if(BLAS_FIND_REQUIRED)
-        message(FATAL_ERROR
-        "A required library with BLAS API not found. Please specify library location."
-        )
-      else()
-        message(STATUS
-        "A library with BLAS API not found. Please specify library location."
-        )
-      endif()
+      foreach(_search ${BLAS_SEARCH_LIBS})
+        string(REPLACE " " ";" _search ${_search})
+        if(NOT ${_BLAS_LIBRARIES})
+          check_blas_libraries(
+            ${_BLAS_LIBRARIES}
+            BLAS
+            ${BLAS_mkl_SEARCH_SYMBOL}
+            ""
+            "${_search}"
+            "${CMAKE_THREAD_LIBS_INIT};${BLAS_mkl_LM};${BLAS_mkl_LDL}"
+            "${BLAS_mkl_MKLROOT}"
+            "${BLAS_mkl_LIB_PATH_SUFFIXES}"
+            )
+        endif()
+      endforeach()
+
+      unset(_search)
+      unset(BLAS_mkl_ILP_MODE)
+      unset(BLAS_mkl_INTFACE)
+      unset(BLAS_mkl_THREADING)
+      unset(BLAS_mkl_OMP)
+      unset(BLAS_mkl_DLL_SUFFIX)
+      unset(BLAS_mkl_LM)
+      unset(BLAS_mkl_LDL)
+      unset(BLAS_mkl_MKLROOT)
+      unset(BLAS_mkl_MKLROOT_LAST_DIR)
+      unset(BLAS_mkl_ARCH_NAME)
+      unset(BLAS_mkl_OS_NAME)
+      unset(BLAS_mkl_LIB_PATH_SUFFIXES)
     endif()
   endif()
 endif()
 
-set(CMAKE_FIND_LIBRARY_SUFFIXES ${_blas_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+if(BLA_F95)
+  find_package_handle_standard_args(BLAS REQUIRED_VARS BLAS95_LIBRARIES)
+  set(BLAS95_FOUND ${BLAS_FOUND})
+  if(BLAS_FOUND)
+    set(BLAS_LIBRARIES "${BLAS95_LIBRARIES}")
+  endif()
+endif()
+
+# gotoblas? (http://www.tacc.utexas.edu/tacc-projects/gotoblas2)
+if(BLA_VENDOR STREQUAL "Goto" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "goto2"
+      ""
+      ""
+      ""
+      )
+  endif()
+endif()
+
+# FlexiBLAS? (http://www.mpi-magdeburg.mpg.de/mpcsc/software/FlexiBLAS/)
+if(BLA_VENDOR STREQUAL "FlexiBLAS" OR BLA_VENDOR STREQUAL "All")
+  set(_blas_flexiblas_lib "flexiblas")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_flexiblas_lib "64")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_flexiblas_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  unset(_blas_flexiblas_lib)
+endif()
+
+# OpenBLAS? (http://www.openblas.net)
+if(BLA_VENDOR STREQUAL "OpenBLAS" OR BLA_VENDOR STREQUAL "All")
+  set(_blas_openblas_lib "openblas")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_openblas_lib "64")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_openblas_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+  if(NOT BLAS_LIBRARIES AND (CMAKE_C_COMPILER_LOADED OR CMAKE_CXX_COMPILER_LOADED))
+    if(BLAS_FIND_QUIETLY OR NOT BLAS_FIND_REQUIRED)
+      find_package(Threads)
+    else()
+      find_package(Threads REQUIRED)
+    endif()
+    set(_threadlibs "${CMAKE_THREAD_LIBS_INIT}")
+    if(BLA_STATIC)
+      if (CMAKE_C_COMPILER_LOADED)
+        find_package(OpenMP QUIET COMPONENTS C)
+        list(PREPEND _threadlibs "${OpenMP_C_LIBRARIES}")
+      elseif(CMAKE_CXX_COMPILER_LOADED)
+        find_package(OpenMP QUIET COMPONENTS CXX)
+        list(PREPEND _threadlibs "${OpenMP_CXX_LIBRARIES}")
+      endif()
+    endif()
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_openblas_lib}"
+      "${_threadlibs}"
+      ""
+      ""
+      )
+    unset(_threadlibs)
+  endif()
+
+  unset(_blas_openblas_lib)
+endif()
+
+# ArmPL blas library? (https://developer.arm.com/tools-and-software/server-and-hpc/compile/arm-compiler-for-linux/arm-performance-libraries)
+if(BLA_VENDOR MATCHES "Arm" OR BLA_VENDOR STREQUAL "All")
+
+   # Check for 64bit Integer support
+  if(_blas_sizeof_integer EQUAL 8)
+    set(_blas_armpl_lib "armpl_ilp64")
+  elseif(_blas_sizeof_integer EQUAL 4)
+    set(_blas_armpl_lib "armpl_lp64")
+  else()
+    if(BLA_VENDOR MATCHES "_ilp64")
+      set(_blas_armpl_lib "armpl_ilp64")
+    else()
+      set(_blas_armpl_lib "armpl_lp64")
+    endif()
+  endif()
+
+   # Check for OpenMP support, VIA BLA_VENDOR of Arm_mp or Arm_ipl64_mp
+   if(BLA_VENDOR MATCHES "_mp")
+     string(APPEND _blas_armpl_lib "_mp")
+   endif()
+
+   if(NOT BLAS_LIBRARIES)
+     check_blas_libraries(
+       BLAS_LIBRARIES
+       BLAS
+       sgemm
+       ""
+       "${_blas_armpl_lib}"
+       ""
+       ""
+       ""
+       )
+  endif()
+  unset(_blas_armpl_lib)
+endif()
+
+# FLAME's blis library? (https://github.com/flame/blis)
+if(BLA_VENDOR STREQUAL "FLAME" OR BLA_VENDOR STREQUAL "All")
+  set(_blas_flame_lib "blis")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_flame_lib "64")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_flame_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  unset(_blas_flame_lib)
+endif()
+
+# BLAS in the ATLAS library? (http://math-atlas.sourceforge.net/)
+if(BLA_VENDOR STREQUAL "ATLAS" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      dgemm
+      ""
+      "blas;f77blas;atlas"
+      ""
+      ""
+      ""
+      )
+  endif()
+endif()
+
+# BLAS in PhiPACK libraries? (requires generic BLAS lib, too)
+if(BLA_VENDOR STREQUAL "PhiPACK" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "sgemm;dgemm;blas"
+      ""
+      ""
+      ""
+      )
+  endif()
+endif()
+
+# BLAS in Alpha CXML library?
+if(BLA_VENDOR STREQUAL "CXML" OR BLA_VENDOR STREQUAL "All")
+  if(_blas_sizeof_integer EQUAL 8)
+    if(BLA_VENDOR STREQUAL "CXML")
+      message(FATAL_ERROR "CXML does not support Int64 type")
+    endif()
+  else()
+    if(NOT BLAS_LIBRARIES)
+      check_blas_libraries(
+        BLAS_LIBRARIES
+        BLAS
+        sgemm
+        ""
+        "cxml"
+        ""
+        ""
+        ""
+        )
+    endif()
+  endif()
+endif()
+
+# BLAS in Alpha DXML library? (now called CXML, see above)
+if(BLA_VENDOR STREQUAL "DXML" OR BLA_VENDOR STREQUAL "All")
+  if(_blas_sizeof_integer EQUAL 8)
+    if(BLA_VENDOR STREQUAL "DXML")
+      message(FATAL_ERROR "DXML does not support Int64 type")
+    endif()
+  else()
+    if(NOT BLAS_LIBRARIES)
+      check_blas_libraries(
+        BLAS_LIBRARIES
+        BLAS
+        sgemm
+        ""
+        "dxml"
+        ""
+        ""
+        ""
+        )
+    endif()
+  endif()
+endif()
+
+# BLAS in Sun Performance library?
+if(BLA_VENDOR STREQUAL "SunPerf" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      "-xlic_lib=sunperf"
+      "sunperf;sunmath"
+      ""
+      ""
+      ""
+      )
+    if(BLAS_LIBRARIES)
+      set(BLAS_LINKER_FLAGS "-xlic_lib=sunperf")
+    endif()
+  endif()
+endif()
+
+# BLAS in SCSL library?  (SGI/Cray Scientific Library)
+if(BLA_VENDOR MATCHES "SCSL" OR BLA_VENDOR STREQUAL "All")
+  set(_blas_scsl_lib "scs")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_scsl_lib "_i8")
+  endif()
+  if(BLA_VENDOR MATCHES "_mp")
+    string(APPEND _blas_scsl_lib "_mp")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_scsl_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  unset(_blas_scsl_lib)
+endif()
+
+# BLAS in SGIMATH library?
+if(BLA_VENDOR STREQUAL "SGIMATH" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "complib.sgimath"
+      ""
+      ""
+      ""
+      )
+  endif()
+endif()
+
+# BLAS in IBM ESSL library?
+if(BLA_VENDOR MATCHES "IBMESSL" OR BLA_VENDOR STREQUAL "All")
+  set(_blas_essl_lib "essl")
+
+  if(BLA_VENDOR MATCHES "_SMP")
+    string(APPEND _blas_essl_lib "smp")
+  endif()
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_essl_lib "6464")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_essl_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  unset(_blas_essl_lib)
+endif()
+
+# BLAS in acml library?
+if(BLA_VENDOR MATCHES "ACML" OR BLA_VENDOR STREQUAL "All")
+  if(((BLA_VENDOR STREQUAL "ACML") AND (NOT BLAS_ACML_LIB_DIRS)) OR
+    ((BLA_VENDOR STREQUAL "ACML_MP") AND (NOT BLAS_ACML_MP_LIB_DIRS)) OR
+    ((BLA_VENDOR STREQUAL "ACML_GPU") AND (NOT BLAS_ACML_GPU_LIB_DIRS))
+    )
+  # try to find acml in "standard" paths
+  if(WIN32)
+    file(GLOB _ACML_ROOT "C:/AMD/acml*/ACML-EULA.txt")
+  else()
+    file(GLOB _ACML_ROOT "/opt/acml*/ACML-EULA.txt")
+  endif()
+  if(WIN32)
+    file(GLOB _ACML_GPU_ROOT "C:/AMD/acml*/GPGPUexamples")
+  else()
+    file(GLOB _ACML_GPU_ROOT "/opt/acml*/GPGPUexamples")
+  endif()
+  list(GET _ACML_ROOT 0 _ACML_ROOT)
+  list(GET _ACML_GPU_ROOT 0 _ACML_GPU_ROOT)
+  if(_ACML_ROOT)
+    get_filename_component(_ACML_ROOT ${_ACML_ROOT} PATH)
+    if(_blas_sizeof_integer EQUAL 8)
+      set(_ACML_PATH_SUFFIX "_int64")
+    else()
+      set(_ACML_PATH_SUFFIX "")
+    endif()
+    if(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+      set(_ACML_COMPILER32 "ifort32")
+      set(_ACML_COMPILER64 "ifort64")
+    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
+      # 32-bit not supported
+      set(_ACML_COMPILER64 "ifx")
+    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "SunPro")
+      set(_ACML_COMPILER32 "sun32")
+      set(_ACML_COMPILER64 "sun64")
+    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "PGI")
+      set(_ACML_COMPILER32 "pgi32")
+      if(WIN32)
+        set(_ACML_COMPILER64 "win64")
+      else()
+        set(_ACML_COMPILER64 "pgi64")
+      endif()
+    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Open64")
+      # 32 bit builds not supported on Open64 but for code simplicity
+      # We'll just use the same directory twice
+      set(_ACML_COMPILER32 "open64_64")
+      set(_ACML_COMPILER64 "open64_64")
+    elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
+      set(_ACML_COMPILER32 "nag32")
+      set(_ACML_COMPILER64 "nag64")
+    else()
+      set(_ACML_COMPILER32 "gfortran32")
+      set(_ACML_COMPILER64 "gfortran64")
+    endif()
+
+    if(BLA_VENDOR STREQUAL "ACML_MP")
+      set(_ACML_MP_LIB_DIRS
+        "${_ACML_ROOT}/${_ACML_COMPILER32}_mp${_ACML_PATH_SUFFIX}/lib"
+        "${_ACML_ROOT}/${_ACML_COMPILER64}_mp${_ACML_PATH_SUFFIX}/lib")
+    else()
+      set(_ACML_LIB_DIRS
+        "${_ACML_ROOT}/${_ACML_COMPILER32}${_ACML_PATH_SUFFIX}/lib"
+        "${_ACML_ROOT}/${_ACML_COMPILER64}${_ACML_PATH_SUFFIX}/lib")
+    endif()
+  endif()
+elseif(BLAS_${BLA_VENDOR}_LIB_DIRS)
+  set(_${BLA_VENDOR}_LIB_DIRS ${BLAS_${BLA_VENDOR}_LIB_DIRS})
+endif()
+
+if(BLA_VENDOR STREQUAL "ACML_MP")
+  foreach(BLAS_ACML_MP_LIB_DIRS ${_ACML_MP_LIB_DIRS})
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      "" "acml_mp;acml_mv" "" ${BLAS_ACML_MP_LIB_DIRS} ""
+      )
+    if(BLAS_LIBRARIES)
+      break()
+    endif()
+  endforeach()
+elseif(BLA_VENDOR STREQUAL "ACML_GPU")
+  foreach(BLAS_ACML_GPU_LIB_DIRS ${_ACML_GPU_LIB_DIRS})
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      "" "acml;acml_mv;CALBLAS" "" ${BLAS_ACML_GPU_LIB_DIRS} ""
+      )
+    if(BLAS_LIBRARIES)
+      break()
+    endif()
+  endforeach()
+else()
+  foreach(BLAS_ACML_LIB_DIRS ${_ACML_LIB_DIRS})
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      "" "acml;acml_mv" "" ${BLAS_ACML_LIB_DIRS} ""
+      )
+    if(BLAS_LIBRARIES)
+      break()
+    endif()
+  endforeach()
+endif()
+
+# Either acml or acml_mp should be in LD_LIBRARY_PATH but not both
+if(NOT BLAS_LIBRARIES)
+  check_blas_libraries(
+    BLAS_LIBRARIES
+    BLAS
+    sgemm
+    ""
+    "acml;acml_mv"
+    ""
+    ""
+    ""
+    )
+endif()
+if(NOT BLAS_LIBRARIES)
+  check_blas_libraries(
+    BLAS_LIBRARIES
+    BLAS
+    sgemm
+    ""
+    "acml_mp;acml_mv"
+    ""
+    ""
+    ""
+    )
+endif()
+if(NOT BLAS_LIBRARIES)
+  check_blas_libraries(
+    BLAS_LIBRARIES
+    BLAS
+    sgemm
+    ""
+    "acml;acml_mv;CALBLAS"
+    ""
+    ""
+    ""
+    )
+endif()
+endif() # ACML
+
+# Apple BLAS library?
+if(BLA_VENDOR STREQUAL "Apple" OR BLA_VENDOR STREQUAL "All")
+  if(_blas_sizeof_integer EQUAL 8)
+    if(BLA_VENDOR STREQUAL "Apple")
+      message(FATAL_ERROR "Accelerate Framework does not support Int64 type")
+    endif()
+  else()
+    if(NOT BLAS_LIBRARIES)
+      check_blas_libraries(
+        BLAS_LIBRARIES
+        BLAS
+        dgemm
+        ""
+        "Accelerate"
+        ""
+        ""
+        ""
+        )
+    endif()
+  endif()
+endif()
+
+# Apple NAS (vecLib) library?
+if(BLA_VENDOR STREQUAL "NAS" OR BLA_VENDOR STREQUAL "All")
+  if(_blas_sizeof_integer EQUAL 8)
+    if(BLA_VENDOR STREQUAL "NAS")
+      message(FATAL_ERROR "Accelerate Framework does not support Int64 type")
+    endif()
+  else()
+    if(NOT BLAS_LIBRARIES)
+      check_blas_libraries(
+        BLAS_LIBRARIES
+        BLAS
+        dgemm
+        ""
+        "vecLib"
+        ""
+        ""
+        ""
+        )
+    endif()
+  endif()
+endif()
+
+# Elbrus Math Library?
+if(BLA_VENDOR MATCHES "EML" OR BLA_VENDOR STREQUAL "All")
+
+  set(_blas_eml_lib "eml")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_eml_lib "_ilp64")
+  endif()
+  # Check for OpenMP support, VIA BLA_VENDOR of eml_mt
+  if(BLA_VENDOR MATCHES "_mt")
+    string(APPEND _blas_eml_lib "_mt")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_eml_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+  unset(_blas_eml_lib)
+endif()
+
+# Fujitsu SSL2 Library?
+if(NOT BLAS_LIBRARIES
+    AND (BLA_VENDOR MATCHES "^Fujitsu_SSL2" OR BLA_VENDOR STREQUAL "All"))
+  set(_blas_fjlapack_lib "fjlapack")
+  set(_blas_fjlapack_flags "-Kopenmp")
+
+  if(BLA_VENDOR MATCHES "BLAMP")
+    string(APPEND _blas_fjlapack_lib "ex")
+  endif()
+  if(BLA_VENDOR MATCHES "SVE")
+    string(APPEND _blas_fjlapack_lib "sve")
+  endif()
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_fjlapack_lib "_ilp64")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      "${_blas_fjlapack_flags}"
+      "${_blas_fjlapack_lib}"
+      ""
+      ""
+      ""
+      )
+    if(BLAS_LIBRARIES)
+      set(BLAS_LINKER_FLAGS ${_blas_fjlapack_flags})
+    endif()
+  endif()
+
+  unset(_blas_fjlapack_flags)
+  unset(_blas_fjlapack_lib)
+endif()
+
+# BLAS in nVidia HPC SDK? (https://developer.nvidia.com/hpc-sdk)
+if(BLA_VENDOR STREQUAL "NVHPC" OR BLA_VENDOR STREQUAL "All")
+  set(_blas_nvhpc_lib "blas")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_nvhpc_lib "_ilp64")
+  elseif(_blas_sizeof_integer EQUAL 4)
+    string(APPEND _blas_nvhpc_lib "_lp64")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_nvhpc_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  # an additional check for NVHPC 2020
+  # which does not have differentiation
+  # between lp64 and ilp64 modes
+  if(NOT BLAS_LIBRARIES AND NOT _blas_sizeof_integer EQUAL 8)
+    set(_blas_nvhpc_lib "blas")
+
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_nvhpc_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  unset(_blas_nvhpc_lib)
+endif()
+
+# Generic BLAS library?
+if(BLA_VENDOR STREQUAL "Generic" OR
+   BLA_VENDOR STREQUAL "All")
+  set(_blas_generic_lib "blas")
+
+  if(_blas_sizeof_integer EQUAL 8)
+    string(APPEND _blas_generic_lib "64")
+  endif()
+
+  if(NOT BLAS_LIBRARIES)
+    check_blas_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      sgemm
+      ""
+      "${_blas_generic_lib}"
+      ""
+      ""
+      ""
+      )
+  endif()
+
+  unset(_blas_generic_lib)
+endif()
+
+# On compilers that implicitly link BLAS (i.e. CrayPrgEnv) we used a
+# placeholder for empty BLAS_LIBRARIES to get through our logic above.
+if(BLAS_LIBRARIES STREQUAL "BLAS_LIBRARIES-PLACEHOLDER-FOR-EMPTY-LIBRARIES")
+  set(BLAS_LIBRARIES "")
+endif()
+
+if(NOT BLA_F95)
+  find_package_handle_standard_args(BLAS REQUIRED_VARS ${_blas_fphsa_req_var})
+endif()
+
+_add_blas_target()
+unset(_blas_fphsa_req_var)
+unset(_blas_sizeof_integer)
+unset(_BLAS_LIBRARIES)

--- a/cmake/Modules/FindLAPACK.cmake
+++ b/cmake/Modules/FindLAPACK.cmake
@@ -1,358 +1,761 @@
-# - Find LAPACK library
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
 
-# This module finds an installed fortran library that implements the LAPACK
-# linear-algebra interface (see http://www.netlib.org/lapack/).
-#
-# The approach follows that taken for the autoconf macro file, acx_lapack.m4
+#[=======================================================================[.rst:
+FindLAPACK
+----------
+
+Find Linear Algebra PACKage (LAPACK) library
+
+This module finds an installed Fortran library that implements the
+`LAPACK linear-algebra interface`_.
+
+At least one of the ``C``, ``CXX``, or ``Fortran`` languages must be enabled.
+
+.. _`LAPACK linear-algebra interface`: http://www.netlib.org/lapack/
+
+Input Variables
+^^^^^^^^^^^^^^^
+
+The following variables may be set to influence this module's behavior:
+
+``BLA_STATIC``
+  if ``ON`` use static linkage
+
+``BLA_VENDOR``
+  Set to one of the :ref:`BLAS/LAPACK Vendors` to search for BLAS only
+  from the specified vendor.  If not set, all vendors are considered.
+
+``BLA_F95``
+  if ``ON`` tries to find the BLAS95/LAPACK95 interfaces
+
+``BLA_PREFER_PKGCONFIG``
+  .. versionadded:: 3.20
+
+  if set ``pkg-config`` will be used to search for a LAPACK library first
+  and if one is found that is preferred
+
+``BLA_SIZEOF_INTEGER``
+  .. versionadded:: 3.22
+
+  Specify the BLAS/LAPACK library integer size:
+
+  ``4``
+    Search for a BLAS/LAPACK with 32-bit integer interfaces.
+  ``8``
+    Search for a BLAS/LAPACK with 64-bit integer interfaces.
+  ``ANY``
+    Search for any BLAS/LAPACK.
+    Most likely, a BLAS/LAPACK with 32-bit integer interfaces will be found.
+
+Imported targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` targets:
+
+``LAPACK::LAPACK``
+  .. versionadded:: 3.18
+
+  The libraries to use for LAPACK, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``LAPACK_FOUND``
+  library implementing the LAPACK interface is found
+``LAPACK_LINKER_FLAGS``
+  uncached list of required linker flags (excluding ``-l`` and ``-L``).
+``LAPACK_LIBRARIES``
+  uncached list of libraries (using full path name) to link against
+  to use LAPACK
+``LAPACK95_LIBRARIES``
+  uncached list of libraries (using full path name) to link against
+  to use LAPACK95
+``LAPACK95_FOUND``
+  library implementing the LAPACK95 interface is found
+
+Intel MKL
+^^^^^^^^^
+
+To use the Intel MKL implementation of LAPACK, a project must enable at least
+one of the ``C`` or ``CXX`` languages.  Set ``BLA_VENDOR`` to an Intel MKL
+variant either on the command-line as ``-DBLA_VENDOR=Intel10_64lp`` or in
+project code:
+
+.. code-block:: cmake
+
+  set(BLA_VENDOR Intel10_64lp)
+  find_package(LAPACK)
+
+In order to build a project using Intel MKL, and end user must first
+establish an Intel MKL environment.  See the :module:`FindBLAS` module
+section on :ref:`Intel MKL` for details.
+
+#]=======================================================================]
+
+# The approach follows that of the ``autoconf`` macro file, ``acx_lapack.m4``
 # (distributed at http://ac-archive.sourceforge.net/ac-archive/acx_lapack.html).
-#
-# This module sets the following variables:
-#  LAPACK_FOUND - set to true if a library implementing the LAPACK interface
-#    is found
-#  LAPACK_LINKER_FLAGS - uncached list of required linker flags (excluding -l
-#    and -L).
-#  LAPACK_LIBRARIES - uncached list of libraries (using full path name) to
-#    link against to use LAPACK
-#  LAPACK95_LIBRARIES - uncached list of libraries (using full path name) to
-#    link against to use LAPACK95
-#  LAPACK95_FOUND - set to true if a library implementing the LAPACK f95
-#    interface is found
-#  BLA_STATIC  if set on this determines what kind of linkage we do (static)
-#  BLA_VENDOR  if set checks only the specified vendor, if not set checks
-#     all the possibilities
-#  BLA_F95     if set on tries to find the f95 interfaces for BLAS/LAPACK
-### List of vendors (BLA_VENDOR) valid in this module
-##  Intel(mkl), ACML,Apple, NAS, Generic
 
-#=============================================================================
-# Copyright 2007-2009 Kitware, Inc.
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
-# (To distribute this file outside of CMake, substitute the full
-#  License text for the above reference.)
+if(CMAKE_Fortran_COMPILER_LOADED)
+  include(${CMAKE_CURRENT_LIST_DIR}/CheckFortranFunctionExists.cmake)
+else()
+  include(${CMAKE_CURRENT_LIST_DIR}/CheckFunctionExists.cmake)
+endif()
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
 
-set(_lapack_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+function(_add_lapack_target)
+  if(LAPACK_FOUND AND NOT TARGET LAPACK::LAPACK)
+    add_library(LAPACK::LAPACK INTERFACE IMPORTED)
 
-get_property(_LANGUAGES_ GLOBAL PROPERTY ENABLED_LANGUAGES)
-if (NOT _LANGUAGES_ MATCHES Fortran)
-include(CheckFunctionExists)
-else (NOT _LANGUAGES_ MATCHES Fortran)
-include(CheckFortranFunctionExists)
-endif (NOT _LANGUAGES_ MATCHES Fortran)
-
-set(LAPACK_FOUND FALSE)
-set(LAPACK95_FOUND FALSE)
-
-# TODO: move this stuff to separate module
-
-macro(Check_Lapack_Libraries LIBRARIES _prefix _name _flags _list _blas _threads)
-# This macro checks for the existence of the combination of fortran libraries
-# given by _list.  If the combination is found, this macro checks (using the
-# Check_Fortran_Function_Exists macro) whether can link against that library
-# combination using the name of a routine given by _name using the linker
-# flags given by _flags.  If the combination of libraries is found and passes
-# the link test, LIBRARIES is set to the list of complete library paths that
-# have been found.  Otherwise, LIBRARIES is set to FALSE.
-
-# N.B. _prefix is the prefix applied to the names of all cached variables that
-# are generated internally and marked advanced by this macro.
-
-set(_libraries_work TRUE)
-set(${LIBRARIES})
-set(_combined_name)
-if (NOT _libdir)
-  if (WIN32)
-    set(_libdir $ENV{LIB})
-  elseif (APPLE)
-    set(_libdir /usr/local/lib /usr/lib /usr/local/lib64 /usr/lib64 $ENV{DYLD_LIBRARY_PATH})
-  else ()
-    set(_libdir /usr/local/lib /usr/lib /usr/local/lib64 /usr/lib64 $ENV{LD_LIBRARY_PATH})
-  endif ()
-endif ()
-foreach(_library ${_list})
-  set(_combined_name ${_combined_name}_${_library})
-
-  if(_libraries_work)
-    if (BLA_STATIC)
-      if (WIN32)
-        set(CMAKE_FIND_LIBRARY_SUFFIXES .lib ${CMAKE_FIND_LIBRARY_SUFFIXES})
-      endif ( WIN32 )
-      if (APPLE)
-        set(CMAKE_FIND_LIBRARY_SUFFIXES .lib ${CMAKE_FIND_LIBRARY_SUFFIXES})
-      else (APPLE)
-        set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
-      endif (APPLE)
-    else (BLA_STATIC)
-			if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        # for ubuntu's libblas3gf and liblapack3gf packages
-        set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} .so.3gf)
-      endif ()
-    endif (BLA_STATIC)
-    find_library(${_prefix}_${_library}_LIBRARY
-      NAMES ${_library}
-      PATHS ${_libdir}
+    # Filter out redundant BLAS info and replace with the BLAS target
+    set(_lapack_libs "${LAPACK_LIBRARIES}")
+    set(_lapack_flags "${LAPACK_LINKER_FLAGS}")
+    if(TARGET BLAS::BLAS)
+      if(_lapack_libs AND BLAS_LIBRARIES)
+        foreach(_blas_lib IN LISTS BLAS_LIBRARIES)
+          list(REMOVE_ITEM _lapack_libs "${_blas_lib}")
+        endforeach()
+      endif()
+      if(_lapack_flags AND BLAS_LINKER_FLAGS)
+        foreach(_blas_flag IN LISTS BLAS_LINKER_FLAGS)
+          list(REMOVE_ITEM _lapack_flags "${_blas_flag}")
+        endforeach()
+      endif()
+      list(APPEND _lapack_libs BLAS::BLAS)
+    endif()
+    if(_lapack_libs)
+      set_target_properties(LAPACK::LAPACK PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${_lapack_libs}"
       )
-    mark_as_advanced(${_prefix}_${_library}_LIBRARY)
-    set(${LIBRARIES} ${${LIBRARIES}} ${${_prefix}_${_library}_LIBRARY})
-    set(_libraries_work ${${_prefix}_${_library}_LIBRARY})
-  endif(_libraries_work)
-endforeach(_library ${_list})
+    endif()
+    if(_lapack_flags)
+      set_target_properties(LAPACK::LAPACK PROPERTIES
+        INTERFACE_LINK_OPTIONS "${_lapack_flags}"
+      )
+    endif()
+  endif()
+endfunction()
 
-if(_libraries_work)
-  # Test this combination of libraries.
-  if(UNIX AND BLA_STATIC)
-    set(CMAKE_REQUIRED_LIBRARIES ${_flags} "-Wl,--start-group" ${${LIBRARIES}} ${_blas} "-Wl,--end-group" ${_threads})
-  else(UNIX AND BLA_STATIC)
-    set(CMAKE_REQUIRED_LIBRARIES ${_flags} ${${LIBRARIES}} ${_blas} ${_threads})
-  endif(UNIX AND BLA_STATIC)
-#  message("DEBUG: CMAKE_REQUIRED_LIBRARIES = ${CMAKE_REQUIRED_LIBRARIES}")
-  if (NOT _LANGUAGES_ MATCHES Fortran)
-    if (BLA_VENDOR MATCHES "Intel11*")
-      #MKL 11
-      check_function_exists("${_name}" ${_prefix}${_combined_name}_WORKS)
-    else ()
+# TODO: move this stuff to a separate module
+
+function(CHECK_LAPACK_LIBRARIES LIBRARIES _prefix _name _flags _list _deps _addlibdir _subdirs _blas)
+  # This function checks for the existence of the combination of libraries
+  # given by _list.  If the combination is found, this checks whether can link
+  # against that library combination using the name of a routine given by _name
+  # using the linker flags given by _flags.  If the combination of libraries is
+  # found and passes the link test, ${LIBRARIES} is set to the list of complete
+  # library paths that have been found.  Otherwise, ${LIBRARIES} is set to FALSE.
+
+  set(_libraries_work TRUE)
+  set(_libraries)
+  set(_combined_name)
+
+  if(BLA_STATIC)
+    if(WIN32)
+      set(CMAKE_FIND_LIBRARY_SUFFIXES .lib ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    else()
+      set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    endif()
+  else()
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      # for ubuntu's libblas3gf and liblapack3gf packages
+      set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} .so.3gf)
+    endif()
+  endif()
+
+  set(_extaddlibdir "${_addlibdir}")
+  if(WIN32)
+    list(APPEND _extaddlibdir ENV LIB)
+  elseif(APPLE)
+    list(APPEND _extaddlibdir ENV DYLD_LIBRARY_PATH)
+  else()
+    list(APPEND _extaddlibdir ENV LD_LIBRARY_PATH)
+  endif()
+  list(APPEND _extaddlibdir "${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}")
+
+  foreach(_library ${_list})
+    if(_library MATCHES "^-")
+      # Respect linker flags as-is (required by MKL)
+      list(APPEND _libraries "${_library}")
+    else()
+      string(REGEX REPLACE "[^A-Za-z0-9]" "_" _lib_var "${_library}")
+      string(APPEND _combined_name "_${_lib_var}")
+      if(NOT "${_deps}" STREQUAL "")
+        string(APPEND _combined_name "_deps")
+      endif()
+      if(_libraries_work)
+        find_library(${_prefix}_${_lib_var}_LIBRARY
+          NAMES ${_library}
+          NAMES_PER_DIR
+          PATHS ${_extaddlibdir}
+          PATH_SUFFIXES ${_subdirs}
+        )
+        mark_as_advanced(${_prefix}_${_lib_var}_LIBRARY)
+        list(APPEND _libraries ${${_prefix}_${_lib_var}_LIBRARY})
+        set(_libraries_work ${${_prefix}_${_lib_var}_LIBRARY})
+      endif()
+    endif()
+  endforeach()
+
+  foreach(_flag ${_flags})
+    string(REGEX REPLACE "[^A-Za-z0-9]" "_" _flag_var "${_flag}")
+    string(APPEND _combined_name "_${_flag_var}")
+  endforeach()
+  if(_libraries_work)
+    # Test this combination of libraries.
+    set(CMAKE_REQUIRED_LIBRARIES ${_flags} ${_libraries} ${_blas} ${_deps})
+    set(CMAKE_REQUIRED_QUIET ${LAPACK_FIND_QUIETLY})
+    if(CMAKE_Fortran_COMPILER_LOADED)
+      check_fortran_function_exists("${_name}" ${_prefix}${_combined_name}_WORKS)
+    else()
       check_function_exists("${_name}_" ${_prefix}${_combined_name}_WORKS)
     endif()
-  else (NOT _LANGUAGES_ MATCHES Fortran)
-    check_fortran_function_exists(${_name} ${_prefix}${_combined_name}_WORKS)
-  endif (NOT _LANGUAGES_ MATCHES Fortran)
-  set(CMAKE_REQUIRED_LIBRARIES)
-  mark_as_advanced(${_prefix}${_combined_name}_WORKS)
-  set(_libraries_work ${${_prefix}${_combined_name}_WORKS})
-  #message("DEBUG: ${LIBRARIES} = ${${LIBRARIES}}")
-endif(_libraries_work)
+    set(CMAKE_REQUIRED_LIBRARIES)
+    set(_libraries_work ${${_prefix}${_combined_name}_WORKS})
+  endif()
 
- if(_libraries_work)
-   set(${LIBRARIES} ${${LIBRARIES}} ${_blas} ${_threads})
- else(_libraries_work)
-    set(${LIBRARIES} FALSE)
- endif(_libraries_work)
+  if(_libraries_work)
+    if("${_list}${_blas}" STREQUAL "")
+      set(_libraries "${LIBRARIES}-PLACEHOLDER-FOR-EMPTY-LIBRARIES")
+    else()
+      list(APPEND _libraries ${_blas} ${_deps})
+    endif()
+  else()
+    set(_libraries FALSE)
+  endif()
+  set(${LIBRARIES} "${_libraries}" PARENT_SCOPE)
+endfunction()
 
-endmacro(Check_Lapack_Libraries)
+macro(_lapack_find_dependency dep)
+  set(_lapack_quiet_arg)
+  if(LAPACK_FIND_QUIETLY)
+    set(_lapack_quiet_arg QUIET)
+  endif()
+  set(_lapack_required_arg)
+  if(LAPACK_FIND_REQUIRED)
+    set(_lapack_required_arg REQUIRED)
+  endif()
+  find_package(${dep} ${ARGN}
+    ${_lapack_quiet_arg}
+    ${_lapack_required_arg}
+  )
+  if (NOT ${dep}_FOUND)
+    set(LAPACK_NOT_FOUND_MESSAGE "LAPACK could not be found because dependency ${dep} could not be found.")
+  endif()
+
+  set(_lapack_required_arg)
+  set(_lapack_quiet_arg)
+endmacro()
 
 set(LAPACK_LINKER_FLAGS)
 set(LAPACK_LIBRARIES)
 set(LAPACK95_LIBRARIES)
+set(_lapack_fphsa_req_var LAPACK_LIBRARIES)
 
-if(LAPACK_FIND_QUIETLY OR NOT LAPACK_FIND_REQUIRED)
-  find_package(BLAS)
-else(LAPACK_FIND_QUIETLY OR NOT LAPACK_FIND_REQUIRED)
-  find_package(BLAS REQUIRED)
-endif(LAPACK_FIND_QUIETLY OR NOT LAPACK_FIND_REQUIRED)
+# Check the language being used
+if(NOT (CMAKE_C_COMPILER_LOADED OR CMAKE_CXX_COMPILER_LOADED OR CMAKE_Fortran_COMPILER_LOADED))
+  set(LAPACK_NOT_FOUND_MESSAGE
+    "FindLAPACK requires Fortran, C, or C++ to be enabled.")
+endif()
 
-if(BLAS_FOUND)
-  set(LAPACK_LINKER_FLAGS ${BLAS_LINKER_FLAGS})
-  if ($ENV{BLA_VENDOR} MATCHES ".+")
-    set(BLA_VENDOR $ENV{BLA_VENDOR})
-  else ($ENV{BLA_VENDOR} MATCHES ".+")
-    if(NOT BLA_VENDOR)
-      set(BLA_VENDOR "All")
-    endif(NOT BLA_VENDOR)
-  endif ($ENV{BLA_VENDOR} MATCHES ".+")
+if(NOT BLA_SIZEOF_INTEGER)
+  # in the reality we do not know which API of BLAS/LAPACK is masked in library
+  set(_lapack_sizeof_integer "ANY")
+elseif((BLA_SIZEOF_INTEGER STREQUAL "ANY") OR
+       (BLA_SIZEOF_INTEGER STREQUAL "4") OR
+       (BLA_SIZEOF_INTEGER STREQUAL "8"))
+  set(_lapack_sizeof_integer ${BLA_SIZEOF_INTEGER})
+else()
+  message(FATAL_ERROR "BLA_SIZEOF_INTEGER can have only <no value>, ANY, 4, or 8 values")
+endif()
 
-if (BLA_VENDOR STREQUAL "Goto" OR BLA_VENDOR STREQUAL "All")
- if(NOT LAPACK_LIBRARIES)
-  check_lapack_libraries(
-  LAPACK_LIBRARIES
-  LAPACK
-  cheev
-  ""
-  "goto2"
-  "${BLAS_LIBRARIES}"
-  ""
-  )
- endif(NOT LAPACK_LIBRARIES)
-endif (BLA_VENDOR STREQUAL "Goto" OR BLA_VENDOR STREQUAL "All")
+# Load BLAS
+if(NOT LAPACK_NOT_FOUND_MESSAGE)
+  _lapack_find_dependency(BLAS)
+endif()
 
-
-#acml lapack
- if (BLA_VENDOR MATCHES "ACML.*" OR BLA_VENDOR STREQUAL "All")
-   if (BLAS_LIBRARIES MATCHES ".+acml.+")
-     set (LAPACK_LIBRARIES ${BLAS_LIBRARIES})
-   endif ()
- endif ()
-
-# Apple LAPACK library?
-if (BLA_VENDOR STREQUAL "Apple" OR BLA_VENDOR STREQUAL "All")
- if(NOT LAPACK_LIBRARIES)
-  check_lapack_libraries(
-  LAPACK_LIBRARIES
-  LAPACK
-  cheev
-  ""
-  "Accelerate"
-  "${BLAS_LIBRARIES}"
-  ""
-  )
- endif(NOT LAPACK_LIBRARIES)
-endif (BLA_VENDOR STREQUAL "Apple" OR BLA_VENDOR STREQUAL "All")
-if (BLA_VENDOR STREQUAL "NAS" OR BLA_VENDOR STREQUAL "All")
-  if ( NOT LAPACK_LIBRARIES )
-    check_lapack_libraries(
-    LAPACK_LIBRARIES
-    LAPACK
-    cheev
-    ""
-    "vecLib"
-    "${BLAS_LIBRARIES}"
-    ""
-    )
-  endif ( NOT LAPACK_LIBRARIES )
-endif (BLA_VENDOR STREQUAL "NAS" OR BLA_VENDOR STREQUAL "All")
-
-# Generic LAPACK library?
-if (BLA_VENDOR STREQUAL "Generic" OR
-    BLA_VENDOR STREQUAL "ATLAS" OR
-    BLA_VENDOR STREQUAL "All")
-  if (BLA_STATIC)
-    set(_flags "gfortran")#needed by itpp-external
-  else()
-    set(_flags " ")
+# Search with pkg-config if specified
+if(BLA_PREFER_PKGCONFIG)
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PKGC_LAPACK QUIET lapack)
+  if(PKGC_LAPACK_FOUND)
+    set(LAPACK_FOUND TRUE)
+    set(LAPACK_LIBRARIES "${PKGC_LAPACK_LINK_LIBRARIES}")
+    if (BLAS_LIBRARIES)
+      list(APPEND LAPACK_LIBRARIES "${BLAS_LIBRARIES}")
+    endif()
+    _add_lapack_target()
+    return()
   endif()
-  if ( NOT LAPACK_LIBRARIES )
-    check_lapack_libraries(
-    LAPACK_LIBRARIES
-    LAPACK
-    cheev
-    ${_flags}
-    "lapack"
-    "${BLAS_LIBRARIES}"
-    ""
-    )
-  endif ( NOT LAPACK_LIBRARIES )
-endif ()
+endif()
 
-#intel lapack
-if (BLA_VENDOR MATCHES "Intel*" OR BLA_VENDOR STREQUAL "All")
-  if (NOT WIN32)
-    set(LM "-lm")
-  endif ()
-  if (_LANGUAGES_ MATCHES C OR _LANGUAGES_ MATCHES CXX)
-    if(LAPACK_FIND_QUIETLY OR NOT LAPACK_FIND_REQUIRED)
-      find_PACKAGE(Threads)
-    else(LAPACK_FIND_QUIETLY OR NOT LAPACK_FIND_REQUIRED)
-      find_package(Threads REQUIRED)
-    endif(LAPACK_FIND_QUIETLY OR NOT LAPACK_FIND_REQUIRED)
-    if (BLA_F95)
-      if(NOT LAPACK95_LIBRARIES)
-        # old
-        check_lapack_libraries(
-          LAPACK95_LIBRARIES
-          LAPACK
-          cheev
-          ""
-          "mkl_lapack95"
-          "${BLAS95_LIBRARIES}"
-          "${CMAKE_THREAD_LIBS_INIT};${LM}"
-          )
-      endif(NOT LAPACK95_LIBRARIES)
-      if(NOT LAPACK95_LIBRARIES)
-        # new >= 10.3
-        check_lapack_libraries(
-          LAPACK95_LIBRARIES
-          LAPACK
-          CHEEV
-          ""
-          "mkl_intel_lp64"
-          "${BLAS95_LIBRARIES}"
-          "${CMAKE_THREAD_LIBS_INIT};${LM}"
-          )
-      endif(NOT LAPACK95_LIBRARIES)
-    else(BLA_F95)
-      if(NOT LAPACK_LIBRARIES)
-        # old
-        check_lapack_libraries(
-          LAPACK_LIBRARIES
-          LAPACK
-          cheev
-          ""
-          "mkl_lapack"
-          "${BLAS_LIBRARIES}"
-          "${CMAKE_THREAD_LIBS_INIT};${LM}"
-          )
-      endif(NOT LAPACK_LIBRARIES)
-      if(NOT LAPACK_LIBRARIES)
-        # new >= 10.3
-        check_lapack_libraries(
-          LAPACK_LIBRARIES
-          LAPACK
-          cheev
-          ""
-          "mkl_gf_lp64"
-          "${BLAS_LIBRARIES}"
-          "${CMAKE_THREAD_LIBS_INIT};${LM}"
-          )
-      endif(NOT LAPACK_LIBRARIES)
-      if(NOT LAPACK_LIBRARIES)
-        # new >= 11
-        check_lapack_libraries(
-          LAPACK_LIBRARIES
-          LAPACK
-          cheev
-          ""
-          "mkl_rt"
-          "${BLAS_LIBRARIES}"
-          "${CMAKE_THREAD_LIBS_INIT};${LM}"
-          )
+# Search for different LAPACK distributions if BLAS is found
+if(NOT LAPACK_NOT_FOUND_MESSAGE)
+  set(LAPACK_LINKER_FLAGS ${BLAS_LINKER_FLAGS})
+  if(NOT $ENV{BLA_VENDOR} STREQUAL "")
+    set(BLA_VENDOR $ENV{BLA_VENDOR})
+  elseif(NOT BLA_VENDOR)
+    set(BLA_VENDOR "All")
+  endif()
+
+  # LAPACK in the Intel MKL 10+ library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "Intel" OR BLA_VENDOR STREQUAL "All")
+      AND (CMAKE_C_COMPILER_LOADED OR CMAKE_CXX_COMPILER_LOADED))
+    # System-specific settings
+    if(NOT WIN32)
+      set(LAPACK_mkl_LM "-lm")
+      set(LAPACK_mkl_LDL "-ldl")
+    endif()
+
+    _lapack_find_dependency(Threads)
+
+    if(_lapack_sizeof_integer EQUAL 8)
+      set(LAPACK_mkl_ILP_MODE "ilp64")
+    elseif(_lapack_sizeof_integer EQUAL 4)
+      set(LAPACK_mkl_ILP_MODE "lp64")
+    else()
+      if(BLA_VENDOR MATCHES "_64ilp")
+        set(LAPACK_mkl_ILP_MODE "ilp64")
+      else()
+        set(LAPACK_mkl_ILP_MODE "lp64")
       endif()
-    endif(BLA_F95)
-  endif (_LANGUAGES_ MATCHES C OR _LANGUAGES_ MATCHES CXX)
-endif(BLA_VENDOR MATCHES "Intel*" OR BLA_VENDOR STREQUAL "All")
-else(BLAS_FOUND)
-  message(STATUS "LAPACK requires BLAS")
-endif(BLAS_FOUND)
+    endif()
+
+    set(LAPACK_SEARCH_LIBS "")
+
+    if(BLA_F95)
+      set(LAPACK_mkl_SEARCH_SYMBOL "cheev_f95")
+      set(_LAPACK_LIBRARIES LAPACK95_LIBRARIES)
+      set(_BLAS_LIBRARIES ${BLAS95_LIBRARIES})
+
+      # old
+      list(APPEND LAPACK_SEARCH_LIBS
+        "mkl_lapack95")
+      # new >= 10.3
+      list(APPEND LAPACK_SEARCH_LIBS
+        "mkl_intel_c")
+      list(APPEND LAPACK_SEARCH_LIBS
+        "mkl_lapack95_${LAPACK_mkl_ILP_MODE}")
+    else()
+      set(LAPACK_mkl_SEARCH_SYMBOL "cheev")
+      set(_LAPACK_LIBRARIES LAPACK_LIBRARIES)
+      set(_BLAS_LIBRARIES ${BLAS_LIBRARIES})
+
+      # old and new >= 10.3
+      list(APPEND LAPACK_SEARCH_LIBS
+        "mkl_lapack")
+    endif()
+
+    # MKL uses a multitude of partially platform-specific subdirectories:
+    if(BLA_VENDOR STREQUAL "Intel10_32")
+      set(LAPACK_mkl_ARCH_NAME "ia32")
+    else()
+      set(LAPACK_mkl_ARCH_NAME "intel64")
+    endif()
+    if(WIN32)
+      set(LAPACK_mkl_OS_NAME "win")
+    elseif(APPLE)
+      set(LAPACK_mkl_OS_NAME "mac")
+    else()
+      set(LAPACK_mkl_OS_NAME "lin")
+    endif()
+    if(DEFINED ENV{MKLROOT})
+      file(TO_CMAKE_PATH "$ENV{MKLROOT}" LAPACK_mkl_MKLROOT)
+      # If MKLROOT points to the subdirectory 'mkl', use the parent directory instead
+      # so we can better detect other relevant libraries in 'compiler' or 'tbb':
+      get_filename_component(LAPACK_mkl_MKLROOT_LAST_DIR "${LAPACK_mkl_MKLROOT}" NAME)
+      if(LAPACK_mkl_MKLROOT_LAST_DIR STREQUAL "mkl")
+          get_filename_component(LAPACK_mkl_MKLROOT "${LAPACK_mkl_MKLROOT}" DIRECTORY)
+      endif()
+    endif()
+    set(LAPACK_mkl_LIB_PATH_SUFFIXES
+        "compiler/lib" "compiler/lib/${LAPACK_mkl_ARCH_NAME}_${LAPACK_mkl_OS_NAME}"
+        "compiler/lib/${LAPACK_mkl_ARCH_NAME}"
+        "mkl/lib" "mkl/lib/${LAPACK_mkl_ARCH_NAME}_${LAPACK_mkl_OS_NAME}"
+        "mkl/lib/${LAPACK_mkl_ARCH_NAME}"
+        "lib" "lib/${LAPACK_mkl_ARCH_NAME}_${LAPACK_mkl_OS_NAME}"
+        "lib/${LAPACK_mkl_ARCH_NAME}"
+        )
+
+    # First try empty lapack libs (implicitly linked or automatic from BLAS)
+    if(NOT ${_LAPACK_LIBRARIES})
+      check_lapack_libraries(
+        ${_LAPACK_LIBRARIES}
+        LAPACK
+        ${LAPACK_mkl_SEARCH_SYMBOL}
+        ""
+        ""
+        "${CMAKE_THREAD_LIBS_INIT};${LAPACK_mkl_LM};${LAPACK_mkl_LDL}"
+        "${LAPACK_mkl_MKLROOT}"
+        "${LAPACK_mkl_LIB_PATH_SUFFIXES}"
+        "${_BLAS_LIBRARIES}"
+      )
+      if(LAPACK_WORKS AND NOT _BLAS_LIBRARIES)
+        # Give a more helpful "found" message
+        set(LAPACK_WORKS "implicitly linked")
+        set(_lapack_fphsa_req_var LAPACK_WORKS)
+      endif()
+    endif()
+
+    # Then try the search libs
+    foreach(_search ${LAPACK_SEARCH_LIBS})
+      string(REPLACE " " ";" _search ${_search})
+      if(NOT ${_LAPACK_LIBRARIES})
+        check_lapack_libraries(
+          ${_LAPACK_LIBRARIES}
+          LAPACK
+          ${LAPACK_mkl_SEARCH_SYMBOL}
+          ""
+          "${_search}"
+          "${CMAKE_THREAD_LIBS_INIT};${LAPACK_mkl_LM};${LAPACK_mkl_LDL}"
+          "${LAPACK_mkl_MKLROOT}"
+          "${LAPACK_mkl_LIB_PATH_SUFFIXES}"
+          "${_BLAS_LIBRARIES}"
+        )
+      endif()
+    endforeach()
+
+    unset(_search)
+    unset(LAPACK_mkl_ILP_MODE)
+    unset(LAPACK_mkl_SEARCH_SYMBOL)
+    unset(LAPACK_mkl_LM)
+    unset(LAPACK_mkl_LDL)
+    unset(LAPACK_mkl_MKLROOT)
+    unset(LAPACK_mkl_ARCH_NAME)
+    unset(LAPACK_mkl_OS_NAME)
+    unset(LAPACK_mkl_LIB_PATH_SUFFIXES)
+  endif()
+
+  # gotoblas? (http://www.tacc.utexas.edu/tacc-projects/gotoblas2)
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "Goto" OR BLA_VENDOR STREQUAL "All"))
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "goto2"
+      ""
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+  endif()
+
+  # FlexiBLAS? (http://www.mpi-magdeburg.mpg.de/mpcsc/software/FlexiBLAS/)
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "FlexiBLAS" OR BLA_VENDOR STREQUAL "All"))
+    set(_lapack_flexiblas_lib "flexiblas")
+
+    if(_lapack_sizeof_integer EQUAL 8)
+      string(APPEND _lapack_flexiblas_lib "64")
+    endif()
+
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "${_lapack_flexiblas_lib}"
+      ""
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+
+    unset(_lapack_flexiblas_lib)
+  endif()
+
+  # OpenBLAS? (http://www.openblas.net)
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "OpenBLAS" OR BLA_VENDOR STREQUAL "All"))
+    set(_lapack_openblas_lib "openblas")
+
+    if(_lapack_sizeof_integer EQUAL 8)
+      string(APPEND _lapack_openblas_lib "64")
+    endif()
+
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "${_lapack_openblas_lib}"
+      ""
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+
+    unset(_lapack_openblas_lib)
+  endif()
+
+  # ArmPL? (https://developer.arm.com/tools-and-software/server-and-hpc/compile/arm-compiler-for-linux/arm-performance-libraries)
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "Arm" OR BLA_VENDOR STREQUAL "All"))
+    # Check for 64bit Integer support
+    if(_lapack_sizeof_integer EQUAL 8)
+      set(LAPACK_armpl_LIB "armpl_ilp64")
+    elseif(_lapack_sizeof_integer EQUAL 4)
+      set(LAPACK_armpl_LIB "armpl_lp64")
+    else()
+      if(BLA_VENDOR MATCHES "_ilp64")
+        set(LAPACK_armpl_LIB "armpl_ilp64")
+      else()
+        set(LAPACK_armpl_LIB "armpl_lp64")
+      endif()
+    endif()
+
+    # Check for OpenMP support, VIA BLA_VENDOR of Arm_mp or Arm_ipl64_mp
+    if(BLA_VENDOR MATCHES "_mp")
+      string(APPEND LAPACK_armpl_LIB "_mp")
+    endif()
+
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "${LAPACK_armpl_LIB}"
+      ""
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+  endif()
+
+  # FLAME's blis library? (https://github.com/flame/blis)
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "FLAME" OR BLA_VENDOR STREQUAL "All"))
+    if(_lapack_sizeof_integer EQUAL 8)
+      if(BLA_VENDOR STREQUAL "FLAME")
+        message(FATAL_ERROR "libFLAME does not support Int64 type")
+      endif()
+    else()
+      check_lapack_libraries(
+        LAPACK_LIBRARIES
+        LAPACK
+        cheev
+        ""
+        "flame"
+        ""
+        ""
+        ""
+        "${BLAS_LIBRARIES}"
+      )
+    endif()
+  endif()
+
+  # LAPACK in SCSL library? (SGI/Cray Scientific Library)
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "SCSL" OR BLA_VENDOR STREQUAL "All"))
+    set(_lapack_scsl_lib "scs")
+
+    if(_lapack_sizeof_integer EQUAL 8)
+      string(APPEND _lapack_scsl_lib "_i8")
+    endif()
+    # Check for OpenMP support, VIA BLA_VENDOR of scs_mp
+    if(BLA_VENDOR MATCHES "_mp")
+      string(APPEND _lapack_scsl_lib "_mp")
+    endif()
+
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "${_lapack_scsl_lib}"
+      ""
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+    unset(_lapack_scsl_lib)
+  endif()
+
+  # BLAS in acml library?
+  if(BLA_VENDOR MATCHES "ACML" OR BLA_VENDOR STREQUAL "All")
+    if(BLAS_LIBRARIES MATCHES ".+acml.+")
+      set(LAPACK_LIBRARIES ${BLAS_LIBRARIES})
+    endif()
+  endif()
+
+  # Apple LAPACK library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "Apple" OR BLA_VENDOR STREQUAL "All"))
+    if(_lapack_sizeof_integer EQUAL 8)
+      if(BLA_VENDOR STREQUAL "Apple")
+        message(FATAL_ERROR "Accelerate Framework does not support Int64 type")
+      endif()
+    else()
+      check_lapack_libraries(
+        LAPACK_LIBRARIES
+        LAPACK
+        cheev
+        ""
+        "Accelerate"
+        ""
+        ""
+        ""
+        "${BLAS_LIBRARIES}"
+      )
+    endif()
+  endif()
+
+  # Apple NAS (vecLib) library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "NAS" OR BLA_VENDOR STREQUAL "All"))
+    if(_lapack_sizeof_integer EQUAL 8)
+      if(BLA_VENDOR STREQUAL "NAS")
+        message(FATAL_ERROR "Accelerate Framework does not support Int64 type")
+      endif()
+    else()
+      check_lapack_libraries(
+        LAPACK_LIBRARIES
+        LAPACK
+        cheev
+        ""
+        "vecLib"
+        ""
+        ""
+        ""
+        "${BLAS_LIBRARIES}"
+      )
+    endif()
+  endif()
+
+  # Elbrus Math Library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "EML" OR BLA_VENDOR STREQUAL "All"))
+    if(BLAS_LIBRARIES MATCHES "eml.+")
+      set(LAPACK_LIBRARIES ${BLAS_LIBRARIES})
+    endif()
+  endif()
+
+  # Fujitsu SSL2 Library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "Fujitsu_SSL2" OR BLA_VENDOR STREQUAL "All"))
+    if(BLAS_LIBRARIES MATCHES "fjlapack.+")
+      set(LAPACK_LIBRARIES ${BLAS_LIBRARIES})
+      set(LAPACK_LINKER_FLAGS ${BLAS_LINKER_FLAGS})
+    endif()
+  endif()
+
+  # LAPACK in IBM ESSL library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "IBMESSL" OR BLA_VENDOR STREQUAL "All"))
+    if(BLAS_LIBRARIES MATCHES "essl.+")
+      set(LAPACK_LIBRARIES ${BLAS_LIBRARIES})
+    endif()
+  endif()
+
+  # NVHPC Library?
+
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR MATCHES "NVHPC" OR BLA_VENDOR STREQUAL "All"))
+    set(_lapack_nvhpc_lib "lapack")
+
+    if(_lapack_sizeof_integer EQUAL 8)
+      string(APPEND _lapack_nvhpc_lib "_ilp64")
+    elseif(_lapack_sizeof_integer EQUAL 4)
+      string(APPEND _lapack_nvhpc_lib "_lp64")
+    endif()
+
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "${_lapack_nvhpc_lib}"
+      "-fortranlibs"
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+
+    # an additional check for NVHPC 2020
+    # which does not have differentiation
+    # between lp64 and ilp64 modes
+    if(NOT LAPACK_LIBRARIES AND NOT _lapack_sizeof_integer EQUAL 8)
+      set(_lapack_nvhpc_lib "lapack")
+
+      check_lapack_libraries(
+        LAPACK_LIBRARIES
+        LAPACK
+        cheev
+        ""
+        "${_lapack_nvhpc_lib}"
+        "-fortranlibs"
+        ""
+        ""
+        "${BLAS_LIBRARIES}"
+      )
+    endif()
+
+    unset(_lapack_nvhpc_lib)
+  endif()
+
+  # Generic LAPACK library?
+  if(NOT LAPACK_LIBRARIES
+      AND (BLA_VENDOR STREQUAL "Generic"
+           OR BLA_VENDOR STREQUAL "ATLAS"
+           OR BLA_VENDOR STREQUAL "All"))
+    set(_lapack_generic_lib "lapack")
+    if(BLA_STATIC)
+      # We do not know for sure how the LAPACK reference implementation
+      # is built on this host.  Guess typical dependencies.
+      set(_lapack_generic_deps "-lgfortran;-lm")
+    else()
+      set(_lapack_generic_deps "")
+    endif()
+
+    if(_lapack_sizeof_integer EQUAL 8)
+      string(APPEND _lapack_generic_lib "64")
+    endif()
+
+    check_lapack_libraries(
+      LAPACK_LIBRARIES
+      LAPACK
+      cheev
+      ""
+      "${_lapack_generic_lib}"
+      "${_lapack_generic_deps}"
+      ""
+      ""
+      "${BLAS_LIBRARIES}"
+    )
+
+    unset(_lapack_generic_deps)
+    unset(_lapack_generic_lib)
+  endif()
+endif()
 
 if(BLA_F95)
- if(LAPACK95_LIBRARIES)
-  set(LAPACK95_FOUND TRUE)
- else(LAPACK95_LIBRARIES)
-  set(LAPACK95_FOUND FALSE)
- endif(LAPACK95_LIBRARIES)
- if(NOT LAPACK_FIND_QUIETLY)
-  if(LAPACK95_FOUND)
-    message(STATUS "A library with LAPACK95 API found.")
-  else(LAPACK95_FOUND)
-    if(LAPACK_FIND_REQUIRED)
-      message(FATAL_ERROR
-      "A required library with LAPACK95 API not found. Please specify library location."
-      )
-    else(LAPACK_FIND_REQUIRED)
-      message(STATUS
-      "A library with LAPACK95 API not found. Please specify library location."
-      )
-    endif(LAPACK_FIND_REQUIRED)
-  endif(LAPACK95_FOUND)
- endif(NOT LAPACK_FIND_QUIETLY)
- set(LAPACK_FOUND "${LAPACK95_FOUND}")
- set(LAPACK_LIBRARIES "${LAPACK95_LIBRARIES}")
-else(BLA_F95)
- if(LAPACK_LIBRARIES)
-  set(LAPACK_FOUND TRUE)
- else(LAPACK_LIBRARIES)
-  set(LAPACK_FOUND FALSE)
- endif(LAPACK_LIBRARIES)
+  set(LAPACK_LIBRARIES "${LAPACK95_LIBRARIES}")
+endif()
 
- if(NOT LAPACK_FIND_QUIETLY)
-  if(LAPACK_FOUND)
-    message(STATUS "A library with LAPACK API found.")
-  else(LAPACK_FOUND)
-    if(LAPACK_FIND_REQUIRED)
-      message(FATAL_ERROR
-      "A required library with LAPACK API not found. Please specify library location."
-      )
-    else(LAPACK_FIND_REQUIRED)
-      message(STATUS
-      "A library with LAPACK API not found. Please specify library location."
-      )
-    endif(LAPACK_FIND_REQUIRED)
-  endif(LAPACK_FOUND)
- endif(NOT LAPACK_FIND_QUIETLY)
-endif(BLA_F95)
+if(LAPACK_NOT_FOUND_MESSAGE)
+  set(LAPACK_NOT_FOUND_MESSAGE
+    REASON_FAILURE_MESSAGE ${LAPACK_NOT_FOUND_MESSAGE})
+endif()
+find_package_handle_standard_args(LAPACK REQUIRED_VARS ${_lapack_fphsa_req_var}
+  ${LAPACK_NOT_FOUND_MESSAGE})
+unset(LAPACK_NOT_FOUND_MESSAGE)
 
-set(CMAKE_FIND_LIBRARY_SUFFIXES ${_lapack_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+if(BLA_F95)
+  set(LAPACK95_FOUND ${LAPACK_FOUND})
+endif()
+
+# On compilers that implicitly link LAPACK (such as ftn, cc, and CC on Cray HPC machines)
+# we used a placeholder for empty LAPACK_LIBRARIES to get through our logic above.
+if(LAPACK_LIBRARIES STREQUAL "LAPACK_LIBRARIES-PLACEHOLDER-FOR-EMPTY-LIBRARIES")
+  set(LAPACK_LIBRARIES "")
+endif()
+
+_add_lapack_target()
+unset(_lapack_fphsa_req_var)
+unset(_lapack_sizeof_integer)
+unset(_LAPACK_LIBRARIES)

--- a/cmake/Modules/FindPackageHandleStandardArgs.cmake
+++ b/cmake/Modules/FindPackageHandleStandardArgs.cmake
@@ -1,0 +1,605 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindPackageHandleStandardArgs
+-----------------------------
+
+This module provides functions intended to be used in :ref:`Find Modules`
+implementing :command:`find_package(<PackageName>)` calls.
+
+.. command:: find_package_handle_standard_args
+
+  This command handles the ``REQUIRED``, ``QUIET`` and version-related
+  arguments of :command:`find_package`.  It also sets the
+  ``<PackageName>_FOUND`` variable.  The package is considered found if all
+  variables listed contain valid results, e.g. valid filepaths.
+
+  There are two signatures:
+
+  .. code-block:: cmake
+
+    find_package_handle_standard_args(<PackageName>
+      (DEFAULT_MSG|<custom-failure-message>)
+      <required-var>...
+      )
+
+    find_package_handle_standard_args(<PackageName>
+      [FOUND_VAR <result-var>]
+      [REQUIRED_VARS <required-var>...]
+      [VERSION_VAR <version-var>]
+      [HANDLE_VERSION_RANGE]
+      [HANDLE_COMPONENTS]
+      [CONFIG_MODE]
+      [NAME_MISMATCHED]
+      [REASON_FAILURE_MESSAGE <reason-failure-message>]
+      [FAIL_MESSAGE <custom-failure-message>]
+      )
+
+  The ``<PackageName>_FOUND`` variable will be set to ``TRUE`` if all
+  the variables ``<required-var>...`` are valid and any optional
+  constraints are satisfied, and ``FALSE`` otherwise.  A success or
+  failure message may be displayed based on the results and on
+  whether the ``REQUIRED`` and/or ``QUIET`` option was given to
+  the :command:`find_package` call.
+
+  The options are:
+
+  ``(DEFAULT_MSG|<custom-failure-message>)``
+    In the simple signature this specifies the failure message.
+    Use ``DEFAULT_MSG`` to ask for a default message to be computed
+    (recommended).  Not valid in the full signature.
+
+  ``FOUND_VAR <result-var>``
+    .. deprecated:: 3.3
+
+    Specifies either ``<PackageName>_FOUND`` or
+    ``<PACKAGENAME>_FOUND`` as the result variable.  This exists only
+    for compatibility with older versions of CMake and is now ignored.
+    Result variables of both names are always set for compatibility.
+
+  ``REQUIRED_VARS <required-var>...``
+    Specify the variables which are required for this package.
+    These may be named in the generated failure message asking the
+    user to set the missing variable values.  Therefore these should
+    typically be cache entries such as ``FOO_LIBRARY`` and not output
+    variables like ``FOO_LIBRARIES``.
+
+    .. versionchanged:: 3.18
+      If ``HANDLE_COMPONENTS`` is specified, this option can be omitted.
+
+  ``VERSION_VAR <version-var>``
+    Specify the name of a variable that holds the version of the package
+    that has been found.  This version will be checked against the
+    (potentially) specified required version given to the
+    :command:`find_package` call, including its ``EXACT`` option.
+    The default messages include information about the required
+    version and the version which has been actually found, both
+    if the version is ok or not.
+
+  ``HANDLE_VERSION_RANGE``
+    .. versionadded:: 3.19
+
+    Enable handling of a version range, if one is specified. Without this
+    option, a developer warning will be displayed if a version range is
+    specified.
+
+  ``HANDLE_COMPONENTS``
+    Enable handling of package components.  In this case, the command
+    will report which components have been found and which are missing,
+    and the ``<PackageName>_FOUND`` variable will be set to ``FALSE``
+    if any of the required components (i.e. not the ones listed after
+    the ``OPTIONAL_COMPONENTS`` option of :command:`find_package`) are
+    missing.
+
+  ``CONFIG_MODE``
+    Specify that the calling find module is a wrapper around a
+    call to ``find_package(<PackageName> NO_MODULE)``.  This implies
+    a ``VERSION_VAR`` value of ``<PackageName>_VERSION``.  The command
+    will automatically check whether the package configuration file
+    was found.
+
+  ``REASON_FAILURE_MESSAGE <reason-failure-message>``
+    .. versionadded:: 3.16
+
+    Specify a custom message of the reason for the failure which will be
+    appended to the default generated message.
+
+  ``FAIL_MESSAGE <custom-failure-message>``
+    Specify a custom failure message instead of using the default
+    generated message.  Not recommended.
+
+  ``NAME_MISMATCHED``
+    .. versionadded:: 3.17
+
+    Indicate that the ``<PackageName>`` does not match
+    ``${CMAKE_FIND_PACKAGE_NAME}``. This is usually a mistake and raises a
+    warning, but it may be intentional for usage of the command for components
+    of a larger package.
+
+Example for the simple signature:
+
+.. code-block:: cmake
+
+  find_package_handle_standard_args(LibXml2 DEFAULT_MSG
+    LIBXML2_LIBRARY LIBXML2_INCLUDE_DIR)
+
+The ``LibXml2`` package is considered to be found if both
+``LIBXML2_LIBRARY`` and ``LIBXML2_INCLUDE_DIR`` are valid.
+Then also ``LibXml2_FOUND`` is set to ``TRUE``.  If it is not found
+and ``REQUIRED`` was used, it fails with a
+:command:`message(FATAL_ERROR)`, independent whether ``QUIET`` was
+used or not.  If it is found, success will be reported, including
+the content of the first ``<required-var>``.  On repeated CMake runs,
+the same message will not be printed again.
+
+.. note::
+
+  If ``<PackageName>`` does not match ``CMAKE_FIND_PACKAGE_NAME`` for the
+  calling module, a warning that there is a mismatch is given. The
+  ``FPHSA_NAME_MISMATCHED`` variable may be set to bypass the warning if using
+  the old signature and the ``NAME_MISMATCHED`` argument using the new
+  signature. To avoid forcing the caller to require newer versions of CMake for
+  usage, the variable's value will be used if defined when the
+  ``NAME_MISMATCHED`` argument is not passed for the new signature (but using
+  both is an error)..
+
+Example for the full signature:
+
+.. code-block:: cmake
+
+  find_package_handle_standard_args(LibArchive
+    REQUIRED_VARS LibArchive_LIBRARY LibArchive_INCLUDE_DIR
+    VERSION_VAR LibArchive_VERSION)
+
+In this case, the ``LibArchive`` package is considered to be found if
+both ``LibArchive_LIBRARY`` and ``LibArchive_INCLUDE_DIR`` are valid.
+Also the version of ``LibArchive`` will be checked by using the version
+contained in ``LibArchive_VERSION``.  Since no ``FAIL_MESSAGE`` is given,
+the default messages will be printed.
+
+Another example for the full signature:
+
+.. code-block:: cmake
+
+  find_package(Automoc4 QUIET NO_MODULE HINTS /opt/automoc4)
+  find_package_handle_standard_args(Automoc4  CONFIG_MODE)
+
+In this case, a ``FindAutmoc4.cmake`` module wraps a call to
+``find_package(Automoc4 NO_MODULE)`` and adds an additional search
+directory for ``automoc4``.  Then the call to
+``find_package_handle_standard_args`` produces a proper success/failure
+message.
+
+.. command:: find_package_check_version
+
+  .. versionadded:: 3.19
+
+  Helper function which can be used to check if a ``<version>`` is valid
+  against version-related arguments of :command:`find_package`.
+
+  .. code-block:: cmake
+
+    find_package_check_version(<version> <result-var>
+      [HANDLE_VERSION_RANGE]
+      [RESULT_MESSAGE_VARIABLE <message-var>]
+      )
+
+  The ``<result-var>`` will hold a boolean value giving the result of the check.
+
+  The options are:
+
+  ``HANDLE_VERSION_RANGE``
+    Enable handling of a version range, if one is specified. Without this
+    option, a developer warning will be displayed if a version range is
+    specified.
+
+  ``RESULT_MESSAGE_VARIABLE <message-var>``
+    Specify a variable to get back a message describing the result of the check.
+
+Example for the usage:
+
+.. code-block:: cmake
+
+  find_package_check_version(1.2.3 result HANDLE_VERSION_RANGE
+    RESULT_MESSAGE_VARIABLE reason)
+  if (result)
+    message (STATUS "${reason}")
+  else()
+    message (FATAL_ERROR "${reason}")
+  endif()
+#]=======================================================================]
+
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageMessage.cmake)
+
+
+cmake_policy(PUSH)
+# numbers and boolean constants
+cmake_policy (SET CMP0012 NEW)
+# IN_LIST operator
+cmake_policy (SET CMP0057 NEW)
+
+
+# internal helper macro
+macro(_FPHSA_FAILURE_MESSAGE _msg)
+  set (__msg "${_msg}")
+  if (FPHSA_REASON_FAILURE_MESSAGE)
+    string(APPEND __msg "\n    Reason given by package: ${FPHSA_REASON_FAILURE_MESSAGE}\n")
+  endif()
+  if (${_NAME}_FIND_REQUIRED)
+    message(FATAL_ERROR "${__msg}")
+  else ()
+    if (NOT ${_NAME}_FIND_QUIETLY)
+      message(STATUS "${__msg}")
+    endif ()
+  endif ()
+endmacro()
+
+
+# internal helper macro to generate the failure message when used in CONFIG_MODE:
+macro(_FPHSA_HANDLE_FAILURE_CONFIG_MODE)
+  # <PackageName>_CONFIG is set, but FOUND is false, this means that some other of the REQUIRED_VARS was not found:
+  if(${_NAME}_CONFIG)
+    _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: missing:${MISSING_VARS} (found ${${_NAME}_CONFIG} ${VERSION_MSG})")
+  else()
+    # If _CONSIDERED_CONFIGS is set, the config-file has been found, but no suitable version.
+    # List them all in the error message:
+    if(${_NAME}_CONSIDERED_CONFIGS)
+      set(configsText "")
+      list(LENGTH ${_NAME}_CONSIDERED_CONFIGS configsCount)
+      math(EXPR configsCount "${configsCount} - 1")
+      foreach(currentConfigIndex RANGE ${configsCount})
+        list(GET ${_NAME}_CONSIDERED_CONFIGS ${currentConfigIndex} filename)
+        list(GET ${_NAME}_CONSIDERED_VERSIONS ${currentConfigIndex} version)
+        string(APPEND configsText "\n    ${filename} (version ${version})")
+      endforeach()
+      if (${_NAME}_NOT_FOUND_MESSAGE)
+        if (FPHSA_REASON_FAILURE_MESSAGE)
+          string(PREPEND FPHSA_REASON_FAILURE_MESSAGE "${${_NAME}_NOT_FOUND_MESSAGE}\n    ")
+        else()
+          set(FPHSA_REASON_FAILURE_MESSAGE "${${_NAME}_NOT_FOUND_MESSAGE}")
+        endif()
+      else()
+        string(APPEND configsText "\n")
+      endif()
+      _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE} ${VERSION_MSG}, checked the following files:${configsText}")
+
+    else()
+      # Simple case: No Config-file was found at all:
+      _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: found neither ${_NAME}Config.cmake nor ${_NAME_LOWER}-config.cmake ${VERSION_MSG}")
+    endif()
+  endif()
+endmacro()
+
+
+function(FIND_PACKAGE_CHECK_VERSION version result)
+  cmake_parse_arguments (PARSE_ARGV 2 FPCV "HANDLE_VERSION_RANGE;NO_AUTHOR_WARNING_VERSION_RANGE" "RESULT_MESSAGE_VARIABLE" "")
+
+  if (FPCV_UNPARSED_ARGUMENTS)
+    message (FATAL_ERROR "find_package_check_version(): ${FPCV_UNPARSED_ARGUMENTS}: unexpected arguments")
+  endif()
+  if ("RESULT_MESSAGE_VARIABLE" IN_LIST FPCV_KEYWORDS_MISSING_VALUES)
+    message (FATAL_ERROR "find_package_check_version(): RESULT_MESSAGE_VARIABLE expects an argument")
+  endif()
+
+  set (${result} FALSE PARENT_SCOPE)
+  if (FPCV_RESULT_MESSAGE_VARIABLE)
+    unset (${FPCV_RESULT_MESSAGE_VARIABLE} PARENT_SCOPE)
+  endif()
+
+  if (_CMAKE_FPHSA_PACKAGE_NAME)
+    set (package "${_CMAKE_FPHSA_PACKAGE_NAME}")
+  elseif (CMAKE_FIND_PACKAGE_NAME)
+    set (package "${CMAKE_FIND_PACKAGE_NAME}")
+  else()
+    message (FATAL_ERROR "find_package_check_version(): Cannot be used outside a 'Find Module'")
+  endif()
+
+  if (NOT FPCV_NO_AUTHOR_WARNING_VERSION_RANGE
+      AND ${package}_FIND_VERSION_RANGE AND NOT FPCV_HANDLE_VERSION_RANGE)
+    message(AUTHOR_WARNING
+      "`find_package()` specify a version range but the option "
+      "HANDLE_VERSION_RANGE` is not passed to `find_package_check_version()`. "
+      "Only the lower endpoint of the range will be used.")
+  endif()
+
+
+  set (version_ok FALSE)
+  unset (version_msg)
+
+  if (FPCV_HANDLE_VERSION_RANGE AND ${package}_FIND_VERSION_RANGE)
+    if ((${package}_FIND_VERSION_RANGE_MIN STREQUAL "INCLUDE"
+          AND version VERSION_GREATER_EQUAL ${package}_FIND_VERSION_MIN)
+        AND ((${package}_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE"
+            AND version VERSION_LESS_EQUAL ${package}_FIND_VERSION_MAX)
+          OR (${package}_FIND_VERSION_RANGE_MAX STREQUAL "EXCLUDE"
+            AND version VERSION_LESS ${package}_FIND_VERSION_MAX)))
+      set (version_ok TRUE)
+      set(version_msg "(found suitable version \"${version}\", required range is \"${${package}_FIND_VERSION_RANGE}\")")
+    else()
+      set(version_msg "Found unsuitable version \"${version}\", required range is \"${${package}_FIND_VERSION_RANGE}\"")
+    endif()
+  elseif (DEFINED ${package}_FIND_VERSION)
+    if(${package}_FIND_VERSION_EXACT)       # exact version required
+      # count the dots in the version string
+      string(REGEX REPLACE "[^.]" "" version_dots "${version}")
+      # add one dot because there is one dot more than there are components
+      string(LENGTH "${version_dots}." version_dots)
+      if (version_dots GREATER ${package}_FIND_VERSION_COUNT)
+        # Because of the C++ implementation of find_package() ${package}_FIND_VERSION_COUNT
+        # is at most 4 here. Therefore a simple lookup table is used.
+        if (${package}_FIND_VERSION_COUNT EQUAL 1)
+          set(version_regex "[^.]*")
+        elseif (${package}_FIND_VERSION_COUNT EQUAL 2)
+          set(version_regex "[^.]*\\.[^.]*")
+        elseif (${package}_FIND_VERSION_COUNT EQUAL 3)
+          set(version_regex "[^.]*\\.[^.]*\\.[^.]*")
+        else()
+          set(version_regex "[^.]*\\.[^.]*\\.[^.]*\\.[^.]*")
+        endif()
+        string(REGEX REPLACE "^(${version_regex})\\..*" "\\1" version_head "${version}")
+        if (NOT ${package}_FIND_VERSION VERSION_EQUAL version_head)
+          set(version_msg "Found unsuitable version \"${version}\", but required is exact version \"${${package}_FIND_VERSION}\"")
+        else ()
+          set(version_ok TRUE)
+          set(version_msg "(found suitable exact version \"${_FOUND_VERSION}\")")
+        endif ()
+      else ()
+        if (NOT ${package}_FIND_VERSION VERSION_EQUAL version)
+          set(version_msg "Found unsuitable version \"${version}\", but required is exact version \"${${package}_FIND_VERSION}\"")
+        else ()
+          set(version_ok TRUE)
+          set(version_msg "(found suitable exact version \"${version}\")")
+        endif ()
+      endif ()
+    else()     # minimum version
+      if (${package}_FIND_VERSION VERSION_GREATER version)
+        set(version_msg "Found unsuitable version \"${version}\", but required is at least \"${${package}_FIND_VERSION}\"")
+      else()
+        set(version_ok TRUE)
+        set(version_msg "(found suitable version \"${version}\", minimum required is \"${${package}_FIND_VERSION}\")")
+      endif()
+    endif()
+  else ()
+    set(version_ok TRUE)
+    set(version_msg "(found version \"${version}\")")
+  endif()
+
+  set (${result} ${version_ok} PARENT_SCOPE)
+  if (FPCV_RESULT_MESSAGE_VARIABLE)
+    set (${FPCV_RESULT_MESSAGE_VARIABLE} "${version_msg}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+
+function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
+
+  # Set up the arguments for `cmake_parse_arguments`.
+  set(options  CONFIG_MODE  HANDLE_COMPONENTS NAME_MISMATCHED HANDLE_VERSION_RANGE)
+  set(oneValueArgs  FAIL_MESSAGE  REASON_FAILURE_MESSAGE VERSION_VAR  FOUND_VAR)
+  set(multiValueArgs REQUIRED_VARS)
+
+  # Check whether we are in 'simple' or 'extended' mode:
+  set(_KEYWORDS_FOR_EXTENDED_MODE  ${options} ${oneValueArgs} ${multiValueArgs} )
+  list(FIND _KEYWORDS_FOR_EXTENDED_MODE "${_FIRST_ARG}" INDEX)
+
+  unset(FPHSA_NAME_MISMATCHED_override)
+  if (DEFINED FPHSA_NAME_MISMATCHED)
+    # If the variable NAME_MISMATCHED variable is set, error if it is passed as
+    # an argument. The former is for old signatures, the latter is for new
+    # signatures.
+    list(FIND ARGN "NAME_MISMATCHED" name_mismatched_idx)
+    if (NOT name_mismatched_idx EQUAL "-1")
+      message(FATAL_ERROR
+        "The `NAME_MISMATCHED` argument may only be specified by the argument or "
+        "the variable, not both.")
+    endif ()
+
+    # But use the variable if it is not an argument to avoid forcing minimum
+    # CMake version bumps for calling modules.
+    set(FPHSA_NAME_MISMATCHED_override "${FPHSA_NAME_MISMATCHED}")
+  endif ()
+
+  if(${INDEX} EQUAL -1)
+    set(FPHSA_FAIL_MESSAGE ${_FIRST_ARG})
+    set(FPHSA_REQUIRED_VARS ${ARGN})
+    set(FPHSA_VERSION_VAR)
+  else()
+    cmake_parse_arguments(FPHSA "${options}" "${oneValueArgs}" "${multiValueArgs}"  ${_FIRST_ARG} ${ARGN})
+
+    if(FPHSA_UNPARSED_ARGUMENTS)
+      message(FATAL_ERROR "Unknown keywords given to FIND_PACKAGE_HANDLE_STANDARD_ARGS(): \"${FPHSA_UNPARSED_ARGUMENTS}\"")
+    endif()
+
+    if(NOT FPHSA_FAIL_MESSAGE)
+      set(FPHSA_FAIL_MESSAGE  "DEFAULT_MSG")
+    endif()
+
+    # In config-mode, we rely on the variable <PackageName>_CONFIG, which is set by find_package()
+    # when it successfully found the config-file, including version checking:
+    if(FPHSA_CONFIG_MODE)
+      list(INSERT FPHSA_REQUIRED_VARS 0 ${_NAME}_CONFIG)
+      list(REMOVE_DUPLICATES FPHSA_REQUIRED_VARS)
+      set(FPHSA_VERSION_VAR ${_NAME}_VERSION)
+    endif()
+
+    if(NOT FPHSA_REQUIRED_VARS AND NOT FPHSA_HANDLE_COMPONENTS)
+      message(FATAL_ERROR "No REQUIRED_VARS specified for FIND_PACKAGE_HANDLE_STANDARD_ARGS()")
+    endif()
+  endif()
+
+  if (DEFINED FPHSA_NAME_MISMATCHED_override)
+    set(FPHSA_NAME_MISMATCHED "${FPHSA_NAME_MISMATCHED_override}")
+  endif ()
+
+  if (DEFINED CMAKE_FIND_PACKAGE_NAME
+      AND NOT FPHSA_NAME_MISMATCHED
+      AND NOT _NAME STREQUAL CMAKE_FIND_PACKAGE_NAME)
+    message(AUTHOR_WARNING
+      "The package name passed to `find_package_handle_standard_args` "
+      "(${_NAME}) does not match the name of the calling package "
+      "(${CMAKE_FIND_PACKAGE_NAME}). This can lead to problems in calling "
+      "code that expects `find_package` result variables (e.g., `_FOUND`) "
+      "to follow a certain pattern.")
+  endif ()
+
+  if (${_NAME}_FIND_VERSION_RANGE AND NOT FPHSA_HANDLE_VERSION_RANGE)
+    message(AUTHOR_WARNING
+      "`find_package()` specify a version range but the module ${_NAME} does "
+      "not support this capability. Only the lower endpoint of the range "
+      "will be used.")
+  endif()
+
+  # to propagate package name to FIND_PACKAGE_CHECK_VERSION
+  set(_CMAKE_FPHSA_PACKAGE_NAME "${_NAME}")
+
+  # now that we collected all arguments, process them
+
+  if("x${FPHSA_FAIL_MESSAGE}" STREQUAL "xDEFAULT_MSG")
+    set(FPHSA_FAIL_MESSAGE "Could NOT find ${_NAME}")
+  endif()
+
+  if (FPHSA_REQUIRED_VARS)
+    list(GET FPHSA_REQUIRED_VARS 0 _FIRST_REQUIRED_VAR)
+  endif()
+
+  string(TOUPPER ${_NAME} _NAME_UPPER)
+  string(TOLOWER ${_NAME} _NAME_LOWER)
+
+  if(FPHSA_FOUND_VAR)
+    set(_FOUND_VAR_UPPER ${_NAME_UPPER}_FOUND)
+    set(_FOUND_VAR_MIXED ${_NAME}_FOUND)
+    if(FPHSA_FOUND_VAR STREQUAL _FOUND_VAR_MIXED  OR  FPHSA_FOUND_VAR STREQUAL _FOUND_VAR_UPPER)
+      set(_FOUND_VAR ${FPHSA_FOUND_VAR})
+    else()
+      message(FATAL_ERROR "The argument for FOUND_VAR is \"${FPHSA_FOUND_VAR}\", but only \"${_FOUND_VAR_MIXED}\" and \"${_FOUND_VAR_UPPER}\" are valid names.")
+    endif()
+  else()
+    set(_FOUND_VAR ${_NAME_UPPER}_FOUND)
+  endif()
+
+  # collect all variables which were not found, so they can be printed, so the
+  # user knows better what went wrong (#6375)
+  set(MISSING_VARS "")
+  set(DETAILS "")
+  # check if all passed variables are valid
+  set(FPHSA_FOUND_${_NAME} TRUE)
+  foreach(_CURRENT_VAR ${FPHSA_REQUIRED_VARS})
+    if(NOT ${_CURRENT_VAR})
+      set(FPHSA_FOUND_${_NAME} FALSE)
+      string(APPEND MISSING_VARS " ${_CURRENT_VAR}")
+    else()
+      string(APPEND DETAILS "[${${_CURRENT_VAR}}]")
+    endif()
+  endforeach()
+  if(FPHSA_FOUND_${_NAME})
+    set(${_NAME}_FOUND TRUE)
+    set(${_NAME_UPPER}_FOUND TRUE)
+  else()
+    set(${_NAME}_FOUND FALSE)
+    set(${_NAME_UPPER}_FOUND FALSE)
+  endif()
+
+  # component handling
+  unset(FOUND_COMPONENTS_MSG)
+  unset(MISSING_COMPONENTS_MSG)
+
+  if(FPHSA_HANDLE_COMPONENTS)
+    foreach(comp ${${_NAME}_FIND_COMPONENTS})
+      if(${_NAME}_${comp}_FOUND)
+
+        if(NOT DEFINED FOUND_COMPONENTS_MSG)
+          set(FOUND_COMPONENTS_MSG "found components:")
+        endif()
+        string(APPEND FOUND_COMPONENTS_MSG " ${comp}")
+
+      else()
+
+        if(NOT DEFINED MISSING_COMPONENTS_MSG)
+          set(MISSING_COMPONENTS_MSG "missing components:")
+        endif()
+        string(APPEND MISSING_COMPONENTS_MSG " ${comp}")
+
+        if(${_NAME}_FIND_REQUIRED_${comp})
+          set(${_NAME}_FOUND FALSE)
+          string(APPEND MISSING_VARS " ${comp}")
+        endif()
+
+      endif()
+    endforeach()
+    set(COMPONENT_MSG "${FOUND_COMPONENTS_MSG} ${MISSING_COMPONENTS_MSG}")
+    string(APPEND DETAILS "[c${COMPONENT_MSG}]")
+  endif()
+
+  # version handling:
+  set(VERSION_MSG "")
+  set(VERSION_OK TRUE)
+
+  # check with DEFINED here as the requested or found version may be "0"
+  if (DEFINED ${_NAME}_FIND_VERSION)
+    if(DEFINED ${FPHSA_VERSION_VAR})
+      set(_FOUND_VERSION ${${FPHSA_VERSION_VAR}})
+      if (FPHSA_HANDLE_VERSION_RANGE)
+        set (FPCV_HANDLE_VERSION_RANGE HANDLE_VERSION_RANGE)
+      else()
+        set(FPCV_HANDLE_VERSION_RANGE NO_AUTHOR_WARNING_VERSION_RANGE)
+      endif()
+      find_package_check_version ("${_FOUND_VERSION}" VERSION_OK RESULT_MESSAGE_VARIABLE VERSION_MSG
+        ${FPCV_HANDLE_VERSION_RANGE})
+    else()
+      # if the package was not found, but a version was given, add that to the output:
+      if(${_NAME}_FIND_VERSION_EXACT)
+        set(VERSION_MSG "(Required is exact version \"${${_NAME}_FIND_VERSION}\")")
+      elseif (FPHSA_HANDLE_VERSION_RANGE AND ${_NAME}_FIND_VERSION_RANGE)
+        set(VERSION_MSG "(Required is version range \"${${_NAME}_FIND_VERSION_RANGE}\")")
+      else()
+        set(VERSION_MSG "(Required is at least version \"${${_NAME}_FIND_VERSION}\")")
+      endif()
+    endif()
+  else ()
+    # Check with DEFINED as the found version may be 0.
+    if(DEFINED ${FPHSA_VERSION_VAR})
+      set(VERSION_MSG "(found version \"${${FPHSA_VERSION_VAR}}\")")
+    endif()
+  endif ()
+
+  if(VERSION_OK)
+    string(APPEND DETAILS "[v${${FPHSA_VERSION_VAR}}(${${_NAME}_FIND_VERSION})]")
+  else()
+    set(${_NAME}_FOUND FALSE)
+  endif()
+
+
+  # print the result:
+  if (${_NAME}_FOUND)
+    FIND_PACKAGE_MESSAGE(${_NAME} "Found ${_NAME}: ${${_FIRST_REQUIRED_VAR}} ${VERSION_MSG} ${COMPONENT_MSG}" "${DETAILS}")
+  else ()
+
+    if(FPHSA_CONFIG_MODE)
+      _FPHSA_HANDLE_FAILURE_CONFIG_MODE()
+    else()
+      if(NOT VERSION_OK)
+        set(RESULT_MSG)
+        if (_FIRST_REQUIRED_VAR)
+          string (APPEND RESULT_MSG "found ${${_FIRST_REQUIRED_VAR}}")
+        endif()
+        if (COMPONENT_MSG)
+          if (RESULT_MSG)
+            string (APPEND RESULT_MSG ", ")
+          endif()
+          string (APPEND RESULT_MSG "${FOUND_COMPONENTS_MSG}")
+        endif()
+        _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: ${VERSION_MSG} (${RESULT_MSG})")
+      else()
+        _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE} (missing:${MISSING_VARS}) ${VERSION_MSG}")
+      endif()
+    endif()
+
+  endif ()
+
+  set(${_NAME}_FOUND ${${_NAME}_FOUND} PARENT_SCOPE)
+  set(${_NAME_UPPER}_FOUND ${${_NAME}_FOUND} PARENT_SCOPE)
+endfunction()
+
+
+cmake_policy(POP)

--- a/cmake/Modules/FindPackageMessage.cmake
+++ b/cmake/Modules/FindPackageMessage.cmake
@@ -1,0 +1,48 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindPackageMessage
+------------------
+
+.. code-block:: cmake
+
+  find_package_message(<name> "message for user" "find result details")
+
+This function is intended to be used in FindXXX.cmake modules files.
+It will print a message once for each unique find result.  This is
+useful for telling the user where a package was found.  The first
+argument specifies the name (XXX) of the package.  The second argument
+specifies the message to display.  The third argument lists details
+about the find result so that if they change the message will be
+displayed again.  The macro also obeys the QUIET argument to the
+find_package command.
+
+Example:
+
+.. code-block:: cmake
+
+  if(X11_FOUND)
+    find_package_message(X11 "Found X11: ${X11_X11_LIB}"
+      "[${X11_X11_LIB}][${X11_INCLUDE_DIR}]")
+  else()
+   ...
+  endif()
+#]=======================================================================]
+
+function(find_package_message pkg msg details)
+  # Avoid printing a message repeatedly for the same find result.
+  if(NOT ${pkg}_FIND_QUIETLY)
+    string(REPLACE "\n" "" details "${details}")
+    set(DETAILS_VAR FIND_PACKAGE_MESSAGE_DETAILS_${pkg})
+    if(NOT "${details}" STREQUAL "${${DETAILS_VAR}}")
+      # The message has not yet been printed.
+      message(STATUS "${msg}")
+
+      # Save the find details in the cache to avoid printing the same
+      # message again.
+      set("${DETAILS_VAR}" "${details}"
+        CACHE INTERNAL "Details about finding ${pkg}")
+    endif()
+  endif()
+endfunction()


### PR DESCRIPTION
These modules are copied from https://github.com/Kitware/CMake/tree/master/Modules, and can fix the error to find LAPACK and BLAS on Windows.

Tested platforms (cmake version 3.23.1)
+ Windows, MinGW GCC in MSYS2
+ Windows, MSVC
+ openSUSE tumbleweed